### PR TITLE
[codex] upgrade genlayer-js dependency

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,0 +1,4 @@
+# Matrix overrides consumed by genlayer-e2e when this repo triggers a run.
+# Wallet currently tracks the stable v1 line of genlayer-js.
+tooling:
+  genlayer-js: v1

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@metamask/key-tree": "^10.0.2",
     "ethers": "^6.13.5",
-    "genlayer-js": "^0.6.3"
+    "genlayer-js": "1.1.8"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.0",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@metamask/snaps-sdk": "^6.10.0",
     "ethers": "6.13.5",
-    "genlayer-js": "0.11.2"
+    "genlayer-js": "1.1.8"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -4,10 +4,10 @@
   "proposedName": "Genlayer Wallet",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yeagerai/genlayer-wallet.git"
+    "url": "https://github.com/genlayerlabs/genlayer-wallet.git"
   },
   "source": {
-    "shasum": "eY80XAM15OdmyAec7lzqcy7C3T6bQ611scgsLt6STec=",
+    "shasum": "tT2WRenW6jXHpVBKfiXfbTnZv6I3nOk1A3IGUPcUTfw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,7 +19,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adraffy/ens-normalize@npm:^1.10.1, @adraffy/ens-normalize@npm:^1.11.0":
+"@adraffy/ens-normalize@npm:^1.11.0":
   version: 1.11.0
   resolution: "@adraffy/ens-normalize@npm:1.11.0"
   checksum: b2911269e3e0ec6396a2e5433a99e0e1f9726befc6c167994448cd0e53dbdd0be22b4835b4f619558b568ed9aa7312426b8fa6557a13999463489daa88169ee5
@@ -3553,15 +3553,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.8.1, @noble/curves@npm:^1.6.0, @noble/curves@npm:~1.8.1":
-  version: 1.8.1
-  resolution: "@noble/curves@npm:1.8.1"
-  dependencies:
-    "@noble/hashes": 1.7.1
-  checksum: 4143f1248ed57c1ae46dfef5c692a91383e5830420b9c72d3ff1061aa9ebbf8999297da6d2aed8a9716fef8e6b1f5a45737feeab02abf55ca2a4f514bf9339ec
-  languageName: node
-  linkType: hard
-
 "@noble/curves@npm:1.9.2, @noble/curves@npm:^1.9.1, @noble/curves@npm:~1.9.0":
   version: 1.9.2
   resolution: "@noble/curves@npm:1.9.2"
@@ -3598,13 +3589,6 @@ __metadata:
   version: 1.7.0
   resolution: "@noble/hashes@npm:1.7.0"
   checksum: c06949ead7f5771a74f6fc9a346c7519212b3484c5b7916c8cad6b1b0e5f5f6c997ac3a43c0884ef8b99cfc55fac89058eefb29b6aad1cb41f436c748b316a1c
-  languageName: node
-  linkType: hard
-
-"@noble/hashes@npm:1.7.1, @noble/hashes@npm:^1.5.0, @noble/hashes@npm:~1.7.1":
-  version: 1.7.1
-  resolution: "@noble/hashes@npm:1.7.1"
-  checksum: 4f1b56428a10323feef17e4f437c9093556cb18db06f94d254043fadb69c3da8475f96eb3f8322d41e8670117d7486475a8875e68265c2839f60fd03edd6a616
   languageName: node
   linkType: hard
 
@@ -4562,13 +4546,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/base@npm:~1.2.2, @scure/base@npm:~1.2.4":
-  version: 1.2.4
-  resolution: "@scure/base@npm:1.2.4"
-  checksum: db554eb550a1bd17684af9282e1ad751050a13d4add0e83ad61cc496680d7d1c1c1120ca780e72935a293bb59721c20a006a53a5eec6f6b5bdcd702cf27c8cae
-  languageName: node
-  linkType: hard
-
 "@scure/base@npm:~1.2.5":
   version: 1.2.6
   resolution: "@scure/base@npm:1.2.6"
@@ -4584,17 +4561,6 @@ __metadata:
     "@noble/hashes": ~1.4.0
     "@scure/base": ~1.1.6
   checksum: eff491651cbf2bea8784936de75af5fc020fc1bbb9bcb26b2cfeefbd1fb2440ebfaf30c0733ca11c0ae1e272a2ef4c3c34ba5c9fb3e1091c3285a4272045b0c6
-  languageName: node
-  linkType: hard
-
-"@scure/bip32@npm:1.6.2, @scure/bip32@npm:^1.5.0":
-  version: 1.6.2
-  resolution: "@scure/bip32@npm:1.6.2"
-  dependencies:
-    "@noble/curves": ~1.8.1
-    "@noble/hashes": ~1.7.1
-    "@scure/base": ~1.2.2
-  checksum: e7586619f8a669e522267ce71a90b2d00c3a91da658f1f50e54072cf9f432ba26d2bb4d3d91a5d06932ab96612b8bd038bc31d885bbc048cebfb6509c4a790fc
   languageName: node
   linkType: hard
 
@@ -4616,16 +4582,6 @@ __metadata:
     "@noble/hashes": ~1.4.0
     "@scure/base": ~1.1.6
   checksum: dbb0b27df753eb6c6380010b25cc9a9ea31f9cb08864fc51e69e5880ff7e2b8f85b72caea1f1f28af165e83b72c48dd38617e43fc632779d025b50ba32ea759e
-  languageName: node
-  linkType: hard
-
-"@scure/bip39@npm:1.5.4, @scure/bip39@npm:^1.4.0":
-  version: 1.5.4
-  resolution: "@scure/bip39@npm:1.5.4"
-  dependencies:
-    "@noble/hashes": ~1.7.1
-    "@scure/base": ~1.2.4
-  checksum: 744f302559ad05ee6ea4928572ac8f0b5443e8068fd53234c9c2e158814e910a043c54f0688d05546decadd2ff66e0d0c76355d10e103a28cb8f44efe140857a
   languageName: node
   linkType: hard
 
@@ -6219,7 +6175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:1.0.8, abitype@npm:^1.0.6, abitype@npm:^1.0.8":
+"abitype@npm:1.0.8, abitype@npm:^1.0.8":
   version: 1.0.8
   resolution: "abitype@npm:1.0.8"
   peerDependencies:
@@ -12103,25 +12059,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"genlayer-js@npm:0.11.2":
-  version: 0.11.2
-  resolution: "genlayer-js@npm:0.11.2"
+"genlayer-js@npm:1.1.8":
+  version: 1.1.8
+  resolution: "genlayer-js@npm:1.1.8"
   dependencies:
     eslint-plugin-import: ^2.30.0
     typescript-parsec: ^0.3.4
     viem: ^2.29.0
-  checksum: 52468f71f5dfebcd8e36b96c98598c656916f4b746d5afa952f4a4d823d80edc9a793603189117a19849ca410690a24af1165d49de2774bf87a2f5cef8575f98
-  languageName: node
-  linkType: hard
-
-"genlayer-js@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "genlayer-js@npm:0.6.3"
-  dependencies:
-    eslint-plugin-import: ^2.30.0
-    typescript-parsec: ^0.3.4
-    viem: ^2.21.7
-  checksum: 6413ea7b21e78e96f9f05ac608f7ff211eefc5e9db9190585f1241b1a51a341c35c44a01d7855cb6b4cead8256e352cbec93399f319fa32a875c2c2f4e0340d6
+  checksum: 0cdfdac9b8b6a317e9a07742911026bb39ffdfde8b234bde24bba9d929ec8e312bda145614565807a5ce2384c4c6fc496726d42f6d0fd5b98f3721ce5c1cab14
   languageName: node
   linkType: hard
 
@@ -12151,7 +12096,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
     ethers: 6.13.5
-    genlayer-js: 0.11.2
+    genlayer-js: 1.1.8
     jest: ^29.5.0
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
@@ -12185,7 +12130,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
     ethers: ^6.13.5
-    genlayer-js: ^0.6.3
+    genlayer-js: 1.1.8
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.18
     sharp: ^0.32.6
@@ -13756,15 +13701,6 @@ __metadata:
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
   checksum: db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
-  languageName: node
-  linkType: hard
-
-"isows@npm:1.0.6":
-  version: 1.0.6
-  resolution: "isows@npm:1.0.6"
-  peerDependencies:
-    ws: "*"
-  checksum: ab9e85b50bcc3d70aa5ec875aa2746c5daf9321cb376ed4e5434d3c2643c5d62b1f466d93a05cd2ad0ead5297224922748c31707cb4fbd68f5d05d0479dce99c
   languageName: node
   linkType: hard
 
@@ -16426,26 +16362,6 @@ __metadata:
     object-keys: ^1.1.1
     safe-push-apply: ^1.0.0
   checksum: cc9dd7d85c4ccfbe8109fce307d581ac7ede7b26de892b537873fbce2dc6a206d89aea0630dbb98e47ce0873517cefeaa7be15fcf94aaf4764a3b34b474a5b61
-  languageName: node
-  linkType: hard
-
-"ox@npm:0.6.7":
-  version: 0.6.7
-  resolution: "ox@npm:0.6.7"
-  dependencies:
-    "@adraffy/ens-normalize": ^1.10.1
-    "@noble/curves": ^1.6.0
-    "@noble/hashes": ^1.5.0
-    "@scure/bip32": ^1.5.0
-    "@scure/bip39": ^1.4.0
-    abitype: ^1.0.6
-    eventemitter3: 5.0.1
-  peerDependencies:
-    typescript: ">=5.4.0"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 99acb683ff1cf78749f2b4230d3c208b8cdea0b3bf2bff0db564207917ae6833093b203cb7b9853fc8ec642ca0c8c87cd70a50eab9ff9944c55bf990436112b5
   languageName: node
   linkType: hard
 
@@ -20977,27 +20893,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:^2.21.7":
-  version: 2.22.19
-  resolution: "viem@npm:2.22.19"
-  dependencies:
-    "@noble/curves": 1.8.1
-    "@noble/hashes": 1.7.1
-    "@scure/bip32": 1.6.2
-    "@scure/bip39": 1.5.4
-    abitype: 1.0.8
-    isows: 1.0.6
-    ox: 0.6.7
-    ws: 8.18.0
-  peerDependencies:
-    typescript: ">=5.0.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: d28ac47259c6201c1c79794321551a2699628ae0fd8f475c54ecbc0a9cfbfc2169ed0c9df1a05338d74862b76a30caebd09f2f9e150e517f748d38fc178529e9
-  languageName: node
-  linkType: hard
-
 "viem@npm:^2.29.0":
   version: 2.31.7
   resolution: "viem@npm:2.31.7"
@@ -21433,21 +21328,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 442badcce1f1178ec87a0b5372ae2e9771e07c4929a3180321901f226127f252441e8689d765aa5cfba5f50ac60dd830954afc5aeae81609aefa11d3ddf5cecf
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.18.0":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 91d4d35bc99ff6df483bdf029b9ea4bfd7af1f16fc91231a96777a63d263e1eabf486e13a2353970efc534f9faa43bdbf9ee76525af22f4752cbc5ebda333975
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade wallet genlayer-js dependencies to 1.1.8
- add matrix.yaml so genlayer-e2e can resolve the wallet's genlayer-js track
- rebuild the snap manifest shasum

## Validation

- yarn install
- yarn workspace genlayer-wallet-plugin run build
- yarn workspace genlayer-wallet-plugin run test --runInBand
