### PR TITLE
feat: add fee-aware wallet support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ build/
 coverage/
 .cache/
 public/
+packages/harness/cache/
+packages/harness/out/
+packages/site/static/harness.local.json
 package-lock.json
 
 # Logs

--- a/docs/genlayer-transaction-wallet-architecture.md
+++ b/docs/genlayer-transaction-wallet-architecture.md
@@ -1,0 +1,1159 @@
+# GenLayer Transaction and Wallet Architecture
+
+## Goal
+
+Give users a trustworthy way to send GenLayer transactions from wallets they
+already use, on desktop and mobile, without requiring a new standalone wallet.
+
+The core security requirement is that the user must not rely on dapp-controlled
+UI for gas limits. The user signs or submits a wallet-visible commitment to:
+
+- the GenLayer call
+- the value being sent
+- the gas policy
+- either the actual fee/message configuration or an exact hash of any large
+  nested configuration used in an intent flow
+
+The control plane must live before the wallet prompt. The dapp transaction kit,
+SDK, or an optional preflight wallet interaction can help the user choose a gas
+policy, but the final wallet prompt is a verification surface. It must not be
+treated as a place where the wallet or Snap can rewrite calldata, `msg.value`,
+or fee limits after the dapp has submitted the transaction request.
+
+The architecture should therefore be Snap-independent:
+
+- transaction kit owns policy selection and editing
+- `genlayer-js` builds direct transactions and typed intents
+- ERC-7730 metadata and clear EIP-712 typed data provide standard wallet
+  verification where wallets support them
+- the Snap is an optional MetaMask Extension verifier, not the primary product
+  flow or mobile strategy
+
+## Current Baseline
+
+Today this repo's `genlayer-js` integration builds a direct EVM transaction to
+`ConsensusMain.addTransaction(...)` using the older positional ABI variants:
+
+```solidity
+addTransaction(
+  address sender,
+  address recipient,
+  uint256 numOfInitialValidators,
+  uint256 maxRotations,
+  bytes calldata,
+  uint256 validUntil
+)
+```
+
+The current wallet Snap is a transaction-insight UI. It parses the older
+positional `addTransaction` calldata and the v0.6 fee-aware
+`addTransaction(AddTransactionParams)` / `deploySalted(AddTransactionParams)`
+shape. It extracts the GenLayer recipient, nested method name, user value,
+valid-until, fee distribution, message allocation mode, and message allocation
+summary. It also decodes fee-management calls such as `topUpFees`,
+`submitAppeal`, and `topUpAndSubmitAppeal`.
+
+It still shows an advanced-options form whose values are persisted in Snap
+state, but those options do not modify the transaction. The Snap is therefore a
+verification surface, not the gas-policy control plane.
+
+That limitation is structural for the transaction-insight role: `onTransaction`
+can inspect and warn about the submitted transaction, but it should not be the
+place where GenLayer users edit policy. Any editable Snap experience must happen
+as an explicit preflight flow before transaction construction, for example via
+`wallet_invokeSnap`, and the final `onTransaction` screen must then verify that
+the built transaction matches the chosen policy or policy hash.
+
+The fee-aware consensus interface on `genlayer-consensus` `v0.6` has
+changed the shape to:
+
+```solidity
+function addTransaction(AddTransactionParams memory params) external payable;
+function deploySalted(AddTransactionParams memory params) external payable;
+```
+
+with:
+
+```solidity
+struct AddTransactionParams {
+  address sender;
+  address recipient;
+  uint256 numOfInitialValidators;
+  uint256 maxRotations;
+  uint256 validUntil;
+  uint256 saltNonce;
+  uint256 userValue;
+  IFeeManager.FeesDistribution feesDistribution;
+  bytes txCalldata;
+  IMessages.MessageFeeAllocationNode[] messageAllocations;
+}
+```
+
+`msg.value` is now the sum of consensus fees plus `userValue`. The user-facing
+security and gas policy is mostly in `feesDistribution` and, for message-heavy
+transactions, `messageAllocations`.
+
+The GenLayer transaction id is created after submission inside consensus using
+chain state, timestamp, randomness, and queue state. That means the pre-submit
+object cannot know its final GenLayer tx id. Direct transactions should be
+tracked first by the EVM transaction hash, then linked to the emitted GenLayer
+`txId`. Gateway/relayed transactions should also have an `intentHash`.
+
+## Consensus Fee Fields
+
+The core fee/security struct is:
+
+```solidity
+struct FeesDistribution {
+  uint leaderTimeunitsAllocation;
+  uint validatorTimeunitsAllocation;
+  uint appealRounds;
+  uint executionBudgetPerRound;
+  uint executionConsumed;
+  uint totalMessageFees;
+  uint[] rotations;
+  uint maxPriceGenPerTimeUnit;
+  uint storageFeeMaxGasPrice;
+  uint receiptFeeMaxGasPrice;
+}
+```
+
+For wallet UX, the important fields are:
+
+- `leaderTimeunitsAllocation`: time-unit budget for the leader.
+- `validatorTimeunitsAllocation`: time-unit budget for validators.
+- `appealRounds`: number of appeal rounds pre-funded by the user.
+- `executionBudgetPerRound`: per-round GenVM storage plus receipt/write budget.
+- `executionConsumed`: protocol-managed counter; should not be presented as
+  a user knob for initial submission.
+- `totalMessageFees`: message-fee bucket for transactions that emit messages.
+- `rotations`: array of pre-funded rounds; each value is the max rotations
+  within that round.
+- `maxPriceGenPerTimeUnit`: user cap on `FeeManager.GENPerTimeUnit`; `0` means
+  uncapped legacy behavior.
+- `storageFeeMaxGasPrice`: user cap on the locked GenVM storage unit price.
+- `receiptFeeMaxGasPrice`: user cap on the locked receipt/write gas price.
+
+Message-heavy transactions add a second layer:
+
+```solidity
+struct MessageFeeAllocationNode {
+  uint256 parentIndex;
+  uint8 messageType;
+  bool onAcceptance;
+  address recipient;
+  bytes32 callKey;
+  uint256 budget;
+  bytes feeParams;
+}
+
+struct InternalMessageFeeParams {
+  uint256 leaderTimeunitsAllocation;
+  uint256 validatorTimeunitsAllocation;
+  uint256 appealRounds;
+  uint256 executionBudgetPerRound;
+  uint256[] rotations;
+}
+
+struct ExternalMessageFeeParams {
+  uint256 gasLimit;
+  uint256 maxGasPrice;
+}
+```
+
+There are two practical message modes:
+
+- Mode 1: `totalMessageFees > 0` and `messageAllocations` is empty. The user
+  caps the global message-fee bucket. The contract/SDK must provide each
+  emitted message's `feeParams` and `declaredBudget` at the GenVM emission
+  point; the leader must not invent message budgets after execution.
+- Mode 2: `messageAllocations` is non-empty. The user pre-declares per-recipient
+  and per-`callKey` budgets plus downstream fee params. Exact matches fall back
+  to the per-recipient wildcard `callKey == bytes32(0)`. `messageType` and
+  `onAcceptance` are pinned, and internal `feeParams` must match byte-for-byte.
+  This is the stricter security mode and the one that creates the hardest
+  wallet-display problem.
+
+## Transaction Model
+
+There are two transaction models and several verification layers. Policy
+selection happens before either transaction model is built.
+
+### Direct Consensus Transaction
+
+For EOAs that can verify the transaction clearly, the preferred model is a
+direct EVM transaction to:
+
+```solidity
+ConsensusMainWithFees.addTransaction(AddTransactionParams)
+```
+
+The wallet signs and submits the actual consensus transaction. The clear-signed
+wallet screen is the final user verification surface for `feesDistribution`,
+`messageAllocations`, `userValue`, validators, rotations, and valid-until.
+
+### Gateway Intent
+
+For wallets that cannot verify the direct consensus transaction clearly, use a
+first-class `GenLayerIntent`:
+
+```ts
+type GenLayerIntent = {
+  chainId: number;
+  gateway: `0x${string}`;
+  sender: `0x${string}`;
+  recipient: `0x${string}`;
+  value: bigint;
+  txDataHash: `0x${string}`;
+  numInitialValidators: number;
+  maxRotations: number;
+  validUntil: bigint;
+  gasPolicy: {
+    profileId: string;
+    maxTotalFee: bigint;
+    gasConfigHash: `0x${string}`;
+  };
+  nonce: bigint;
+  deadline: bigint;
+};
+```
+
+This is mainly for relayed, smart-account, gas-sponsored, and mobile flows. A
+signature over this intent does not move native value from an EOA by itself; it
+requires sponsorship, deposit, permit-based payment, or smart-account execution.
+
+The large nested message gas configuration should not be fully displayed on
+small wallet screens. It should be canonicalized, hashed, and represented as:
+
+- profile name
+- max total fee
+- high-level caps
+- `gasConfigHash`
+
+The app can render the full editor. The trusted object is either the direct
+clear-signed `AddTransactionParams` or the signed gateway intent plus exact
+config hash.
+
+## Primary Wallet Insight Strategy
+
+The primary wallet insight strategy should be:
+
+1. ERC-7730 clear-signing metadata for direct consensus transactions and gateway
+   transactions where wallets support it.
+2. Clear EIP-712 typed `GenLayerIntent` signatures for mobile, gasless,
+   unsupported-wallet, and relayed flows.
+3. Wallet-native simulation/risk previews as advisory signals only.
+4. GenLayer Snap as an optional MetaMask Extension verifier and development
+   parser harness.
+
+This makes the system useful across OKX, Rabby, Phantom, MetaMask, Ledger,
+Trezor, WalletConnect, Privy, Reown AppKit, smart accounts, and future wallets
+without depending on one wallet-specific extension surface.
+
+### Clear Signing Metadata
+
+GenLayer should publish ERC-7730 clear-signing metadata for direct consensus
+transactions first, then gateway and intent types.
+
+This helps wallets turn raw calldata or typed-data signing into a human-readable
+confirmation such as:
+
+```txt
+Submit GenLayer transaction
+Recipient: 0x...
+Method: transfer
+Value: 1.0 GEN
+Initial validators: 5
+Max rotations: 2
+Appeal rounds: 1
+Rollup budget per round: 0.02 GEN
+Message fee budget: 0.01 GEN
+Max GEN/time-unit price: 1.2x current
+```
+
+Clear signing is a verification layer over the data the user is actually
+signing. For the direct EOA path, that means it can verify the actual
+`AddTransactionParams` sent to consensus. For the gateway path, it can verify
+the EIP-712 intent or gateway calldata.
+
+Clear signing is not a wallet capability we can assume. The product must know
+whether the active wallet can consume the metadata before routing a high-value
+transaction to the direct path.
+
+Current support should be treated as uneven. Ledger is the clearest live target
+for ERC-7730-style descriptors, while broader browser/mobile wallet support is
+still emerging. OKX, Rabby, and Phantom have useful proprietary transaction
+simulation and risk-preview systems, but GenLayer should not assume those
+wallets can render GenLayer fee semantics from ERC-7730 metadata today. Those
+wallets should be routed through clear EIP-712 intents or explicitly marked as
+simulation-only/unverified until verified support exists.
+
+Required ERC-7730 files:
+
+- `ConsensusMainWithFees.addTransaction(AddTransactionParams)` display
+- `ConsensusMainWithFees.deploySalted(AddTransactionParams)` display
+- `ConsensusMainWithFees.topUpFees(...)` display
+- `ConsensusMainWithFees.topUpAndSubmitAppeal(...)` display
+- `ConsensusMainWithFees.submitAppeal(...)` display
+- ghost-contract relay display, if users enter GenLayer through ghosts
+- `GenLayerGateway.submit(...)` EVM transaction display
+- `GenLayerIntent` EIP-712 typed-data display
+- smart-account `execute(...)` wrapper display where needed
+- ERC-4337 `UserOperation` display where supported
+
+These files must be tightly bound to chain ids, gateway addresses, EIP-712
+domains, consensus addresses, ghost addresses, and deployed contract addresses
+so a wallet does not apply GenLayer formatting to unrelated calldata.
+
+## Supported Execution Paths
+
+### 1. Clear-Signed Direct EOA Transaction
+
+This is the preferred path when the active wallet can clearly display
+GenLayer's fee/security parameters.
+
+Flow:
+
+1. Dapp transaction kit lets the user select a security profile or custom fee
+   policy.
+2. SDK estimates `FeesDistribution`, `userValue`, and `messageAllocations`.
+3. SDK builds `ConsensusMainWithFees.addTransaction(AddTransactionParams)`.
+4. Wallet displays the actual struct through ERC-7730 metadata or equivalent
+   native support.
+5. User sends the EVM transaction directly to consensus.
+6. Explorer/indexer links EVM tx hash to emitted GenLayer `txId`.
+
+This preserves native wallet value movement and does not require a gateway,
+relayer, smart account, or intent signature.
+
+### 2. Optional MetaMask Snap Verification
+
+This is an optional MetaMask Extension enhancement when ERC-7730 support is
+unavailable but the GenLayer Snap is installed. It is not the main control
+plane, not the mobile strategy, and not required for the core architecture.
+
+Flow:
+
+1. Transaction kit and SDK choose the gas policy before building the
+   transaction.
+2. SDK builds the same direct `addTransaction(AddTransactionParams)` call.
+3. Snap `onTransaction` decodes the final calldata and displays the GenLayer
+   method, user value, fees distribution, message allocation mode, and key caps.
+4. Snap warns if the transaction is undecodable, uncapped, has suspicious zero
+   pricing, targets an unknown contract, or does not match a preflight policy
+   hash.
+5. User submits the EVM transaction from MetaMask.
+6. Explorer links EVM tx hash to GenLayer `txId`.
+
+The Snap cannot safely rewrite submitted calldata, `msg.value`, or fee limits
+from the transaction-insight screen. If we keep a Snap-based editor, it must be
+an explicit preflight interaction before the transaction request is created, and
+the final `onTransaction` insight must verify that the submitted transaction
+matches that preflight result.
+
+This does not work on MetaMask Mobile while Snaps remain extension-only. Mobile
+flows should use clear EIP-712 intents, smart accounts, deposits, sponsorship,
+or wallet-call APIs instead.
+
+### 3. Relayed Intent / Gateway
+
+This is the mobile-friendly and gasless-capable path.
+
+Flow:
+
+1. User signs the EIP-712 `GenLayerIntent`.
+2. App or relayer submits it to `GenLayerGateway`.
+3. Gateway verifies the signature, nonce, deadline, calldata hash, value policy,
+   and gas policy.
+4. Gateway submits the GenLayer transaction.
+
+Native value cannot be pulled from an EOA by signature alone. This path requires
+one of:
+
+- relayer sponsorship
+- a prepaid user deposit in the gateway
+- ERC-20 payment through permit or approval
+- a smart account/paymaster path
+
+The gateway path is only safer than direct `addTransaction` if the user signs a
+clear EIP-712 intent, or if the smart-account wallet clearly displays the
+operation. Blind-signing gateway calldata is not an improvement.
+
+### 4. ERC-4337 Smart Account
+
+This should use the same `GenLayerIntent` model, but package execution as a
+`UserOperation` through a smart account.
+
+Flow:
+
+1. App builds intent and call to `GenLayerGateway.submit(...)`.
+2. Smart account validates the user's authorization.
+3. Bundler submits the `UserOperation`.
+4. Paymaster can sponsor or charge another asset.
+5. Gateway still emits the same intent and tx linkage events.
+
+This keeps the GenLayer protocol surface unified. ERC-4337 changes the transport
+and payment model, not the GenLayer intent semantics.
+
+### 5. EIP-7702 / Wallet Call API
+
+Where supported, wallets can expose batching/sponsorship features through
+delegated EOAs or `wallet_sendCalls`. GenLayer should treat these as additional
+transports for either the direct consensus call or the gateway call, not as
+separate transaction semantics.
+
+The SDK should probe capabilities and choose the best available path:
+
+1. clear-signed direct consensus transaction
+2. clear EIP-712 intent with gateway, deposit, sponsorship, permit, or smart
+   account support
+3. smart account / wallet call API with clear operation display
+4. Snap-verified direct consensus transaction for MetaMask Extension users
+5. unsafe fallback only with strong warning or user opt-in
+
+## Wallet Verification Detection
+
+There is no reliable generic RPC today for `wallet_supportsERC7730`.
+
+The transaction kit should implement a conservative verifier:
+
+```ts
+type WalletVerification =
+  | { kind: 'erc7730'; confidence: 'known'; wallet: string }
+  | { kind: 'snap'; confidence: 'installed'; wallet: 'MetaMask' }
+  | { kind: 'smart-account'; confidence: 'capability'; wallet: string }
+  | { kind: 'intent'; confidence: 'typed-data'; wallet: string }
+  | { kind: 'simulation-only'; confidence: 'wallet-specific'; wallet: string }
+  | { kind: 'none'; confidence: 'unknown'; wallet?: string };
+```
+
+Detection inputs:
+
+- EIP-6963 provider identity (`name`, `rdns`) for wallet identification only.
+  EIP-6963 is not reliable feature detection by itself.
+- A maintained GenLayer wallet capability matrix for known ERC-7730 support.
+- MetaMask-specific Snap install checks for the GenLayer Snap.
+- EIP-5792 `wallet_getCapabilities` for wallet-call, batching, paymaster, or
+  smart-account capabilities. It does not currently prove ERC-7730 support.
+- Runtime transaction simulation or preview APIs if a wallet vendor exposes
+  them, but this is wallet-specific.
+
+Routing rule:
+
+```txt
+known ERC-7730 support       -> direct addTransaction
+clear EIP-712 available      -> GenLayerIntent + gateway/relayer
+smart account/paymaster      -> UserOperation or wallet-call path
+MetaMask Snap installed      -> direct addTransaction with Snap verification
+simulation-only wallet       -> treat preview as advisory, prefer typed intent
+unknown wallet               -> block or explicit blind-signing warning
+```
+
+## Stack Support
+
+### `genlayer-consensus`
+
+The direct path depends on the fee-aware interface staying ABI-readable and
+wallet-displayable:
+
+- keep `AddTransactionParams`, `FeesDistribution`, and
+  `MessageFeeAllocationNode[]` as typed ABI data, not opaque `bytes`
+- keep user-controlled caps at top level where possible
+- make `maxPriceGenPerTimeUnit == 0` visibly mean uncapped
+- keep `msg.value == totalFees + userValue` semantics explicit
+- expose view helpers needed by SDKs to quote total fees and top-up deltas
+- expose governance-configured maximum validity window
+- expose governance-configured maximum queue size
+- expose per-recipient queue depth before submission
+- emit enough events for indexers to link EVM tx hash, sender, `userValue`,
+  refunds, fee distribution, queue position, and GenLayer `txId`
+
+The gateway is still useful, but it should not be required for normal EOA
+transactions if direct clear signing is available.
+
+For the optional gateway path:
+
+- EIP-712 domain and type hashes for `GenLayerIntent`
+- nonce and deadline replay protection
+- validation of sender, recipient, value policy, calldata hash, fee config hash,
+  `validUntil`, queue policy, and fee policy fields
+- event linkage from `intentHash` to consensus `txId`
+- support for sponsored, deposited, permit-paid, and smart-account submissions
+
+### Fee, Execution, and GenVM
+
+Fee/security policy must be enforced where spending actually happens.
+
+Required support:
+
+- canonical fee config construction for SDKs and wallet metadata
+- validation that nested message allocations match the submitted tree
+- support for Mode 1 and Mode 2 message-fee semantics
+- execution-time stop/fail/refund rules when limits are reached
+- final receipt fields for quoted max, actual spent, and refund
+
+### `genlayer-js`
+
+Make this the primary integration layer:
+
+- `estimateFeesDistribution`
+- `buildAddTransactionParams`
+- `buildDeploySaltedParams`
+- `sendClearSignedTransaction`
+- `detectWalletVerification`
+- `buildWriteIntent`
+- `buildDeployIntent`
+- `hashFeeConfig`
+- `hashIntent`
+- `signGenLayerIntent`
+- `submitIntent`
+- `getValidityPolicy`
+- `buildValidUntil`
+- `getRecipientQueueStatus`
+- `writeContractWithPolicy`
+- transport selection for clear-signed EOA, clear typed intent, relayed gateway,
+  ERC-4337, wallet call APIs, optional Snap verification, and unsafe fallback
+- return `{ intentHash, evmTxHash, genlayerTxId }`
+- export ERC-7730 metadata artifacts or point wallets to their canonical
+  registry location
+
+The existing client already routes `eth_signTypedData_v4` to wallet providers,
+so typed intent signing fits the current SDK shape.
+
+### `genlayer-py`
+
+Mirror the canonical hashing and signing APIs for bots, CLI, tests, and relayer
+infrastructure:
+
+- same gas config canonicalization
+- same EIP-712 intent hash
+- local account signing
+- fee-aware `AddTransactionParams` builders
+- gateway submit helpers
+
+### `genlayer-node`
+
+Expose RPC support for building safe wallet UI and tracking status:
+
+- `gen_estimateTransactionCost`
+- `gen_validateGasPolicy`
+- `gen_simulateTransactionWithGasPolicy`
+- `gen_getIntentStatus`
+- `gen_getTransactionCostBreakdown`
+- `gen_getValidityPolicy`
+- `gen_getRecipientQueueStatus`
+- `gen_getQueuePolicy`
+- receipt fields for fee policy, message allocation mode, quoted max, actual
+  spend, refund, validity policy, queue depth, and queue position
+- optional `intentHash` fields for gateway/relayed flows
+
+The current `gen_estimateGas` placeholder should become real or be replaced by
+clearer GenLayer-specific estimation methods.
+
+### Relayer
+
+Provide an optional service, not a trust boundary:
+
+- accepts signed intents
+- validates them before submission
+- handles sponsorship, deposits, or permit payment
+- submits to gateway
+- reports status by `intentHash`
+- never gets authority beyond the signed intent
+
+### `genlayer-wallet` Snap
+
+Keep this as an optional MetaMask Extension verification layer and parser test
+harness. It should not own gas policy selection, route selection, or mobile
+coverage.
+
+- maintain decoding for legacy positional `addTransaction`
+- maintain decoding for fee-aware `addTransaction(AddTransactionParams)`
+- maintain decoding for `deploySalted`, `topUpFees`, `submitAppeal`, and
+  `topUpAndSubmitAppeal`
+- decode `GenLayerGateway.submit(...)`
+- show method, recipient, user value, validators, rotations, appeal rounds,
+  execution budget, message-fee mode, `maxPriceGenPerTimeUnit`, and key caps
+- reuse the same field labels and display semantics as the ERC-7730 metadata
+- warn when a transaction cannot be decoded, includes uncapped fee settings,
+  uses zero/suspicious pricing, targets an unknown contract, or has a stale
+  validity window
+- optionally support a preflight policy-selection RPC, but only if the final
+  transaction insight compares the submitted transaction to the selected policy
+  hash
+- optionally show Snap home activity keyed by `intentHash` and `txId`
+
+Snaps are not the mobile strategy because MetaMask Snaps are currently extension
+only. If the Snap work competes with transaction kit, ERC-7730 metadata, or
+gateway intent work, the Snap should be deprioritized.
+
+### Explorer
+
+Index and display the full transaction chain:
+
+- EVM submission tx hash
+- optional `intentHash`
+- signer / sender
+- submitter / relayer where different
+- gateway address only for gateway flows
+- GenLayer `txId`
+- `FeesDistribution`
+- message allocation mode and summary
+- security profile
+- `validUntil` / expiry window
+- recipient queue depth and queue position at submission
+- max fee / quoted budget
+- actual spend
+- refund
+
+Address pages should distinguish signer from submitter. A relayed transaction
+belongs to the signer even if the EVM transaction was sent by the relayer.
+
+### Studio
+
+Use the same model locally:
+
+- gas policy editor
+- simulation against gas policy
+- local fee-aware consensus behavior
+- optional local gateway or gateway-compatible RPC behavior
+- transaction details that show EVM tx hash, GenLayer `txId`, fee policy, and
+  actual cost
+
+### CLI
+
+Expose the same capabilities for developers:
+
+- build and print an intent
+- hash a gas config
+- sign an intent
+- submit an intent
+- submit direct `AddTransactionParams`
+- submit via relayer
+- poll by `intentHash` or `txId`
+
+## Product Surfaces
+
+### Dapp Transaction Kit
+
+This is the main developer-facing package.
+
+Responsibilities:
+
+- render gas policy editor
+- call SDK estimators
+- build `AddTransactionParams` or gateway intents
+- pick transport based on wallet verification support
+- submit or relay
+- display progress from EVM tx hash or `intentHash` to GenLayer `txId` to final
+  receipt
+
+The kit is useful UX, but it is not the trust boundary. The trust boundary is
+either the wallet-verified direct consensus transaction or the wallet-signed
+gateway intent.
+
+The kit should explicitly label the current route:
+
+- verified direct: wallet can clear-sign GenLayer fee config
+- Snap-verified direct: MetaMask Extension plus GenLayer Snap; optional and
+  desktop-only
+- verified intent: user signs EIP-712 and a relayer/smart account submits
+- simulation-only: wallet shows a proprietary risk preview, but GenLayer has not
+  verified clear fee-policy rendering
+- unverified: wallet cannot display fee config; require warning or block
+
+### Framework and Wallet Requirements
+
+The transaction kit must be framework-agnostic at its core. React and Vue should
+be thin adapters over the same transaction, gas policy, signing, submission, and
+receipt parsing logic.
+
+Minimum package shape:
+
+```txt
+@genlayer/transaction-kit/core   -> no React/Vue dependency
+@genlayer/transaction-kit/react  -> hooks and optional React components
+@genlayer/transaction-kit/vue    -> composables and optional Vue components
+```
+
+The core package should accept wallet access through standard adapters:
+
+```ts
+type GenLayerWallet =
+  | { type: 'eip1193'; provider: EIP1193Provider }
+  | { type: 'viem'; walletClient: WalletClient }
+  | { type: 'wagmi'; config: WagmiConfig };
+```
+
+This keeps the plan compatible with MetaMask, WalletConnect, Privy, Reown
+AppKit, injected wallets, and smart accounts. It also avoids a Privy React
+dependency for Vue apps. A Vue app using Privy only needs to hand the core
+package an EIP-1193 provider or viem wallet client.
+
+The UI package should be headless-first:
+
+- export state/controllers independent of DOM rendering
+- provide optional React and Vue components
+- expose CSS custom properties for quick theming
+- expose slots/render props for app-owned layout
+- avoid Shadow DOM in the default components so app styles can reach them
+- let other frameworks use the core controller without wrapping React or Vue
+
+Minimum wallet/provider requirements:
+
+- direct path can call `eth_sendTransaction` or viem `sendTransaction`
+- gateway path can call `eth_signTypedData_v4` or viem `signTypedData`
+- smart-account path can verify ERC-1271 and ERC-6492 signatures at the gateway
+- AppKit / smart-account path can optionally use `wallet_getCapabilities`,
+  `wallet_sendCalls`, and `wallet_getCallsStatus`
+- unknown wallets are allowed only through an explicit unverified route or the
+  clear EIP-712 gateway intent route
+
+### Clear UI Steps Proposal
+
+The default UI should be a transaction sheet, not a marketing page. It should be
+usable as a full page, modal, or embedded widget in React or Vue.
+
+#### Step 1: Connect and Detect
+
+Show:
+
+- connected account
+- detected wallet/provider
+- chain
+- route readiness
+
+Actions:
+
+- connect wallet
+- switch/add chain
+- detect capabilities
+- install/connect Snap only as an optional MetaMask Extension enhancement
+
+Route labels:
+
+- **Verified direct**: clear-signing wallet can decode `AddTransactionParams`
+- **Snap-verified direct**: MetaMask Extension plus GenLayer Snap can decode
+  `AddTransactionParams`
+- **Verified intent**: user will sign EIP-712 gateway intent
+- **Smart account**: transaction will use wallet call / UserOperation semantics
+- **Simulation-only**: wallet may preview transaction effects, but GenLayer fee
+  policy rendering is not verified
+- **Unverified**: wallet cannot show enough detail; block by default for
+  high-risk transactions
+
+#### Step 2: Pick Security Level
+
+Show profiles first:
+
+- Low
+- Standard
+- High
+- Custom
+
+Each profile maps to:
+
+- initial validators
+- rotations
+- appeal rounds
+- max GEN/time-unit cap
+- execution budget
+- message-fee mode
+
+The UI should use plain language next to the profile:
+
+- cheaper / faster
+- balanced
+- higher review budget
+
+#### Step 3: Set Expiry and Queue Awareness
+
+Show expiry as a user-facing duration first:
+
+- 10 minutes
+- 1 hour
+- 1 day
+- 1 week
+- custom
+
+Map the duration to the protocol's canonical `validUntil` representation. If
+the protocol stores an absolute timestamp, the UI should still let users think
+in "expires in" terms and show the resulting exact timestamp in the expanded
+details.
+
+The UI must load and display governance policy:
+
+- maximum allowed `validUntil` window
+- maximum queue size for the recipient contract
+
+The queue preview should show:
+
+- recipient contract queue depth
+- maximum queue size
+- queue fullness percentage
+- whether this transaction would be accepted, warned, or blocked
+
+Rules:
+
+- block or require an explicit override when `validUntil` exceeds the governance
+  max
+- block when queue depth is at or above max queue size
+- warn when queue depth is close to max, for example over 80%
+- explain that queue depth is not a deterministic time estimate unless the
+  target contract exposes better semantics
+
+#### Step 4: Advanced Gas Policy
+
+Collapsed by default. Expands into exact controls:
+
+- leader timeout fee
+- validator timeout fee
+- execution budget per round
+- rotations array
+- max GEN/time-unit cap
+- message mode
+- message allocation tree for Mode 2
+
+Rules:
+
+- show `maxPriceGenPerTimeUnit == 0` as **uncapped**, never as "zero"
+- show nested message budgets as caps, not estimates
+- warn when a nested allocation is much larger than the parent-visible summary
+
+#### Step 5: Transaction Review
+
+Show the application-level transaction:
+
+- method
+- recipient / contract
+- user value
+- calldata summary
+- valid-until
+- expiry duration
+- current queue depth
+- max queue size
+- nonce / salt
+
+Then show the fee/security summary:
+
+- max fee budget
+- user value
+- total `msg.value`
+- fee config hash
+- message allocation mode
+
+The user should be able to expand raw payloads:
+
+- `AddTransactionParams`
+- direct EVM transaction request
+- EIP-712 gateway intent
+
+#### Step 6: Route Confirmation
+
+The call to action depends on the selected route:
+
+- **Send direct GenLayer transaction**
+- **Sign and submit gateway intent**
+- **Submit smart-account operation**
+- **Continue with unverified transaction** only after an explicit warning and
+  only for low-risk/local/dev contexts
+
+Before opening the wallet, show one final short checklist:
+
+- destination contract
+- maximum spend
+- security profile
+- expiry
+- queue status
+- route type
+
+#### Step 7: Wallet Prompt
+
+Expected wallet behavior:
+
+- clear-signed direct path shows decoded `addTransaction(AddTransactionParams)`
+- gateway path shows EIP-712 typed data with fee hash, max spend, recipient,
+  deadline, nonce, and chain/domain
+- smart-account path shows wallet-call/UserOperation details where the wallet
+  supports them
+- optional Snap path shows the same fields in MetaMask transaction insights, but
+  only after the transaction kit has already built the final transaction
+
+If the wallet prompt cannot display enough detail, the app must keep the route
+marked unverified after submission.
+
+#### Step 8: Pending and Final Status
+
+Show progress as separate identifiers:
+
+- EVM tx hash or wallet-call id
+- optional gateway `intentHash`
+- GenLayer `txId`
+- final receipt
+
+Status timeline:
+
+```txt
+Preparing -> Wallet confirmation -> EVM submitted -> GenLayer tx created
+-> Pending consensus -> Accepted/finalized -> Cost/refund complete
+```
+
+The final receipt should show:
+
+- selected max budget
+- actual spend
+- refund
+- validators / rotations used
+- message budgets used
+- links to EVM explorer and GenLayer explorer
+
+### Wallet Confirmations
+
+Clear-signed direct transaction:
+
+- wallet shows a real EVM transaction with `userValue`, fee budget, message
+  budget, and security level
+
+Relayed intent:
+
+- wallet shows EIP-712 signature
+- explorer/app shows status
+- value requires sponsorship, deposit, permit, or smart account
+
+Smart account:
+
+- wallet/smart account shows a UserOperation or wallet call
+- gateway still emits the same events
+
+## Trusted Direct Development Mode
+
+Before gateway intents and broad wallet clear-signing support are ready, we can
+test the user-side fee system through a trusted direct mode.
+
+In this mode, the dapp transaction kit or SDK is treated as the trusted policy
+source. It builds the final `AddTransactionParams`, including `userValue`,
+`feesDistribution`, `messageAllocations`, `validUntil`, and fee deposit. The
+wallet sends the direct consensus transaction, but the test does not require the
+wallet to independently prove that it rendered every GenLayer fee field.
+
+This is a development and CI mode, not the final user trust model. It is useful
+because it exercises the same protocol and tooling payload that later wallet
+verification will inspect:
+
+- direct deploy/write with `feeValue` separate from `userValue`
+- exact time-unit fee budgets and `maxPriceGenPerTimeUnit`
+- top-up, cancel, appeal, and top-up-and-appeal flows
+- Mode 1 message fee bucket behavior
+- Mode 2 message allocation matching
+- execution/storage/receipt budget accounting, spend, and refund reporting
+- Studio and node parity for the same normal tooling scenarios
+
+The e2e suite should therefore run these trusted direct scenarios against both
+Studio and the real node backend. Later, when ERC-7730 metadata, EIP-712
+intents, gateway routing, and transaction-kit wallet detection are ready, the
+same scenario bodies should be reusable with only the route setup changed. The
+assertions should stay focused on the canonical transaction payload and receipt
+accounting rather than on one wallet-specific UI.
+
+For pre-intents wallet coverage, the trusted route is:
+
+1. SDK builds the same fee preset the dapp would recommend.
+2. Studio `sim_call` runs the write with that preset and returns GenVM fee
+   accounting without committing state.
+3. The direct transaction is submitted with the same fee preset.
+4. Tests assert that the submitted transaction records the fee deposit and that
+   Studio/node state changes only after submission.
+
+## Implementation Phases
+
+### Phase 1: Fee-Aware Direct Transaction Spec
+
+- lock `AddTransactionParams` and `FeesDistribution` assumptions
+- define profile-to-`FeesDistribution` mapping
+- define Mode 1 / Mode 2 message-fee UX rules
+- define trusted direct mode as the pre-intents test route
+- add JS/Python hashing test vectors
+- add ERC-7730 clear-signing metadata for direct consensus functions
+- add docs and examples
+
+### Phase 2: SDK and Clear Direct Path
+
+- update `genlayer-js` to build `AddTransactionParams`
+- add estimators and fee profile helpers
+- expose trusted direct submission for local/dev/test environments
+- add wallet verification detection and routing
+- ship direct clear-signed examples
+- keep Snap decode support aligned with the same fixtures, but do not block the
+  core SDK path on Snap availability
+
+### Phase 3: Transaction Kit and Intent Path
+
+- build framework-agnostic gas policy controller
+- ship React and Vue adapters
+- define `GenLayerIntent`
+- add EIP-712 typed-data signing
+- add canonical gas config hashing and test vectors
+- add clear intent review UI and route labels
+
+### Phase 4: Explorer and Node
+
+- index fee/refund/top-up events
+- expose direct transaction cost breakdown and status
+- add estimate/validate/simulate RPCs
+- show actual cost versus selected fee/security cap
+
+### Phase 5: Gateway, Mobile, and Relayer
+
+- deploy `GenLayerGateway`
+- add nonce/deadline/signature verification
+- relayer service
+- deposit/sponsorship/payment model
+- mobile WalletConnect flow
+- transaction kit status UX
+
+### Phase 6: Smart Accounts
+
+- ERC-4337 packaging
+- paymaster support
+- capability probing for wallet call APIs
+- optional EIP-7702 support where wallets expose it safely
+
+### Phase 7: Optional Snap Hardening
+
+- keep struct-based calldata decoding and warnings current with consensus ABI
+- reuse ERC-7730 labels and examples as Snap fixtures
+- add preflight policy-selection RPC only if the final insight can compare the
+  transaction to a policy hash
+- keep Snap work below transaction kit, ERC-7730, and gateway intent work in
+  priority
+
+## Critical Review
+
+This plan is plausible, but it has real implementation risks.
+
+### 1. ERC-7730 Adoption Is Uneven
+
+Clear signing is the cleanest direct-path answer only in wallets that actually
+consume ERC-7730 metadata for the target transaction. There is no standard
+feature-detection RPC for this. The product needs a maintained compatibility
+matrix and conservative routing. Unknown wallets should not silently get the
+same UX label as verified wallets.
+
+### 2. The Hard Part Is `messageAllocations`
+
+`FeesDistribution` is small enough to display. `MessageFeeAllocationNode[]` can
+be a nested budget tree with per-recipient, per-function, and descendant caps.
+Even if ERC-7730 can technically describe the calldata, a hardware or mobile
+wallet may not produce a useful human review for a large tree.
+
+Mitigation:
+
+- prefer bounded profiles for ordinary users
+- show Mode 1 vs Mode 2 clearly
+- show root-level caps and high-risk descendants
+- consider adding a top-level summary/hash field if the raw tree becomes too
+  large for wallet displays
+- test on actual Ledger / ERC-7730 tooling before treating this as solved
+
+### 3. SDK, Metadata, and Snap Must Stay Version-Aware
+
+The SDK, ERC-7730 descriptors, and optional Snap parser must all handle protocol
+versioning explicitly. We need version-aware builders and decoders for:
+
+- legacy positional `ConsensusMain.addTransaction`
+- fee-aware `ConsensusMainWithFees.addTransaction(AddTransactionParams)`
+- `deploySalted`
+- `topUpFees`
+- `topUpAndSubmitAppeal`
+- ghost relay paths
+
+The same test fixtures should drive SDK encoding, ERC-7730 descriptor examples,
+Snap parsing, CLI output, and e2e wallet/tooling tests so a consensus ABI change
+does not silently desynchronize the stack.
+
+### 4. Gateway Is Not Automatically Safer
+
+If an unsupported wallet cannot clear-sign direct consensus calldata, sending an
+opaque EVM transaction to a gateway does not improve the trust problem. Gateway
+fallback only helps when the user signs a clear EIP-712 intent, uses a smart
+account flow with clear operation display, or relies on sponsorship/deposit so
+the final calldata is not the user's blind approval.
+
+### 5. EOA Value Limits the Relayed Path
+
+A relayer cannot pull native `userValue` from an EOA with only a signature. The
+mobile/gateway path needs one of:
+
+- sponsored value
+- prepaid gateway deposit
+- ERC-20 permit/approval payment
+- smart account/paymaster execution
+- a separate EVM transaction, which reintroduces wallet-display requirements
+
+### 6. Fee Cap Semantics Need Careful UX
+
+`maxPriceGenPerTimeUnit == 0` means uncapped legacy behavior. That is easy to
+mislabel as "zero price" or "free". The transaction kit and wallet metadata must
+call it "uncapped". Top-ups can raise a stored cap but cannot tighten it, so the
+top-up UI must explain the resulting cap, not just the delta transaction.
+
+### 7. Metadata Integrity Is Part of Security
+
+ERC-7730 files must be bound to exact chain ids, consensus/gateway addresses,
+EIP-712 domains, and proxy/ghost patterns. A stale or malicious metadata file
+can make dangerous calldata look benign. GenLayer should publish metadata from
+the same release pipeline as contract ABIs and maintain a public registry
+history.
+
+### 8. Interface Flux Requires Versioned Support
+
+The fee docs are still draft and local consensus worktrees can differ from
+`v0.6`. The SDK should use ABI feature detection and chain config
+versions rather than assuming one final signature everywhere.
+
+### 9. Expiry Is a User Policy, Not Just a Timestamp
+
+Users should choose an expiry window in human terms, but the protocol may store
+`validUntil` as an absolute timestamp. The SDK must map between the two and
+enforce governance limits. Wallet and dapp UI should show both the friendly
+duration and the exact resulting timestamp before signing.
+
+### 10. Queue Status Is a Risk Signal, Not a Latency Estimate
+
+Every recipient contract has a queue, but queue depth does not by itself predict
+when a transaction will execute. Poorly designed apps can fill queues by not
+checking pending work. The transaction kit should show queue depth and max queue
+size, but avoid promising execution time unless the target contract or node
+exposes stronger semantics.
+
+### 11. Snap Is Redundant by Design
+
+The Snap overlaps with ERC-7730, EIP-712 intents, and wallet-native previews. That
+is acceptable only if we keep it optional. Its useful roles are MetaMask
+Extension coverage, GenLayer-specific warnings, and parser test coverage. It
+should not become the only editable gas UI, the only safe display path, or a
+requirement for mobile support.
+
+## Recommendation
+
+Use **transaction kit + `genlayer-js` fee-aware builders as the control plane**.
+Use **ERC-7730 clear signing as the primary direct-transaction verification
+path** where wallets support it. Use **clear EIP-712 `GenLayerIntent` signatures
+plus gateway / relayer / smart-account flows for mobile, gasless, sponsorship,
+or wallets that cannot verify direct calldata**. Keep **Snap as optional
+MetaMask Extension coverage only**.
+
+Do not route unsupported wallets into a blind gateway transaction and call that
+safer. Do not depend on Snap for gas policy editing. If a Snap preflight editor
+is kept, the final transaction insight must verify the submitted calldata and
+fee values against the preflight policy hash.
+
+## References
+
+- Clear Signing Alliance: https://clearsigning.org/
+- ERC-7730 structured data clear-signing format: https://eips.ethereum.org/EIPS/eip-7730
+- EIP-6963 provider discovery: https://eips.ethereum.org/EIPS/eip-6963
+- ERC-4337 account abstraction: https://docs.erc4337.io/core-standards/erc-4337
+- EIP-7702 delegated EOAs: https://eips.ethereum.org/EIPS/eip-7702
+- EIP-5792 wallet call API: https://eips.ethereum.org/EIPS/eip-5792
+- MetaMask Snaps FAQ: https://support.metamask.io/configure/snaps/metamask-snaps-faq/

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,4 +1,5 @@
 # Matrix overrides consumed by genlayer-e2e when this repo triggers a run.
-# Wallet currently tracks the stable v1 line of genlayer-js.
+# Wallet fee work tracks the v0.6/M5 fee-aware genlayer-js line until that
+# surface is released on the stable v1 line.
 tooling:
-  genlayer-js: v1
+  genlayer-js: codex/v06-fees-tooling

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
     "snapper:scan": "snapper --path packages/snap --verbose",
     "start": "yarn workspaces foreach --parallel --interlaced --verbose run start",
-    "test": "yarn workspace snap run test"
+    "test": "yarn workspace genlayer-wallet-plugin run test"
   },
   "dependencies": {
     "@metamask/key-tree": "^10.0.2",

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -1,0 +1,35 @@
+# GenLayer Wallet Harness
+
+Local EVM harness for testing the fee-aware GenLayer wallet flow before the
+fee-aware consensus interface is deployed on Bradbury.
+
+## Run
+
+Start Anvil:
+
+```sh
+yarn workspace harness anvil
+```
+
+Deploy the shim and gateway:
+
+```sh
+yarn workspace harness deploy
+```
+
+The deploy script writes `packages/site/static/harness.local.json`, which the
+site loads with the **Load local harness** button.
+
+Optional CLI smoke test:
+
+```sh
+yarn workspace harness smoke
+```
+
+The smoke test submits both paths:
+
+- direct `GenLayerFeeShim.addTransaction(AddTransactionParams)`
+- signed EIP-712 intent through `GenLayerIntentGateway.submitIntent(...)`
+
+After running the smoke test, deploy again if you want the browser flow to start
+from gateway nonce `0`.

--- a/packages/harness/foundry.toml
+++ b/packages/harness/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "src"
+out = "out"
+cache_path = "cache"
+optimizer = true
+optimizer_runs = 200
+via_ir = true
+evm_version = "cancun"

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "harness",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "anvil": "anvil --chain-id 31337 --host 0.0.0.0",
+    "compile": "forge build",
+    "deploy": "node scripts/deploy.mjs",
+    "smoke": "node scripts/smoke.mjs"
+  }
+}

--- a/packages/harness/scripts/deploy.mjs
+++ b/packages/harness/scripts/deploy.mjs
@@ -1,0 +1,80 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ContractFactory, JsonRpcProvider, Wallet } from 'ethers';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const harnessRoot = resolve(__dirname, '..');
+const repoRoot = resolve(harnessRoot, '..', '..');
+
+const rpcUrl = process.env.RPC_URL ?? 'http://127.0.0.1:8545';
+const privateKey =
+  process.env.PRIVATE_KEY ??
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const outputPath =
+  process.env.HARNESS_OUTPUT ??
+  resolve(repoRoot, 'packages/site/static/harness.local.json');
+
+const run = (command, args, cwd) => {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: process.env,
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+};
+
+const readArtifact = (contractName) => {
+  const path = resolve(harnessRoot, 'out', `${contractName}.sol`, `${contractName}.json`);
+  return JSON.parse(readFileSync(path, 'utf8'));
+};
+
+run('forge', ['build'], harnessRoot);
+
+const provider = new JsonRpcProvider(rpcUrl);
+const wallet = new Wallet(privateKey, provider);
+const network = await provider.getNetwork();
+
+const deploy = async (contractName, args = []) => {
+  const artifact = readArtifact(contractName);
+  const factory = new ContractFactory(artifact.abi, artifact.bytecode.object, wallet);
+  const contract = await factory.deploy(...args);
+
+  await contract.waitForDeployment();
+
+  return {
+    artifact,
+    address: await contract.getAddress(),
+    deploymentTransaction: contract.deploymentTransaction()?.hash ?? null,
+  };
+};
+
+const shim = await deploy('GenLayerFeeShim');
+const gateway = await deploy('GenLayerIntentGateway', [shim.address]);
+
+const deployment = {
+  chainId: Number(network.chainId),
+  rpcUrl,
+  deployedAt: new Date().toISOString(),
+  deployer: await wallet.getAddress(),
+  contracts: {
+    shim: {
+      address: shim.address,
+      txHash: shim.deploymentTransaction,
+    },
+    gateway: {
+      address: gateway.address,
+      txHash: gateway.deploymentTransaction,
+    },
+  },
+};
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(deployment, null, 2)}\n`);
+
+console.log(JSON.stringify(deployment, null, 2));

--- a/packages/harness/scripts/smoke.mjs
+++ b/packages/harness/scripts/smoke.mjs
@@ -1,0 +1,193 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  Contract,
+  Interface,
+  JsonRpcProvider,
+  Wallet,
+  hexlify,
+  keccak256,
+  parseEther,
+  toUtf8Bytes,
+} from 'ethers';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const harnessRoot = resolve(__dirname, '..');
+const repoRoot = resolve(harnessRoot, '..', '..');
+
+const rpcUrl = process.env.RPC_URL ?? 'http://127.0.0.1:8545';
+const privateKey =
+  process.env.PRIVATE_KEY ??
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const deploymentPath =
+  process.env.HARNESS_OUTPUT ??
+  resolve(repoRoot, 'packages/site/static/harness.local.json');
+
+const readArtifact = (contractName) => {
+  const path = resolve(harnessRoot, 'out', `${contractName}.sol`, `${contractName}.json`);
+  return JSON.parse(readFileSync(path, 'utf8'));
+};
+
+const provider = new JsonRpcProvider(rpcUrl);
+const wallet = new Wallet(privateKey, provider);
+const deployment = JSON.parse(readFileSync(deploymentPath, 'utf8'));
+const shimArtifact = readArtifact('GenLayerFeeShim');
+const gatewayArtifact = readArtifact('GenLayerIntentGateway');
+const shim = new Contract(deployment.contracts.shim.address, shimArtifact.abi, wallet);
+const gateway = new Contract(
+  deployment.contracts.gateway.address,
+  gatewayArtifact.abi,
+  wallet,
+);
+const events = new Interface([...shimArtifact.abi, ...gatewayArtifact.abi]);
+
+const now = Math.floor(Date.now() / 1000);
+const params = {
+  sender: await wallet.getAddress(),
+  recipient: '0x1111111111111111111111111111111111111111',
+  numOfInitialValidators: 5n,
+  maxRotations: 2n,
+  validUntil: BigInt(now + 3600),
+  saltNonce: 1n,
+  userValue: parseEther('0.01'),
+  feesDistribution: {
+    leaderTimeoutFee: parseEther('0.001'),
+    validatorsTimeoutFee: parseEther('0.002'),
+    appealRounds: 1n,
+    rollupUnifiedBudgetPerRound: parseEther('0.01'),
+    rollupUnifiedConsumed: 0n,
+    totalMessageFees: parseEther('0.02'),
+    rotations: [0n, 1n],
+    maxPriceGenPerTimeUnit: 120n,
+  },
+  txCalldata: hexlify(
+    toUtf8Bytes(JSON.stringify({ method: 'ask_llm', args: [], prototype: true })),
+  ),
+  messageAllocations: [
+    {
+      parentIndex:
+        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn,
+      recipient: '0x2222222222222222222222222222222222222222',
+      functionSelector: '0x00000000',
+      budget: parseEther('0.02'),
+      feeParams: {
+        leaderTimeunitsAllocation: parseEther('0.001'),
+        validatorTimeunitsAllocation: parseEther('0.002'),
+        appealRounds: 1n,
+        rollupUnifiedBudgetPerRound: parseEther('0.005'),
+        rotations: [0n],
+      },
+    },
+  ],
+};
+
+const parseKnownEvents = (receipt) =>
+  receipt.logs.flatMap((log) => {
+    try {
+      const parsed = events.parseLog(log);
+
+      if (!parsed) {
+        return [];
+      }
+
+      if (parsed.name === 'GenLayerTransactionCreated') {
+        return [
+          {
+            name: parsed.name,
+            txId: parsed.args.txId,
+            sender: parsed.args.sender,
+            recipient: parsed.args.recipient,
+            feeConfigHash: parsed.args.feeConfigHash,
+          },
+        ];
+      }
+
+      if (parsed.name === 'IntentSubmitted') {
+        return [
+          {
+            name: parsed.name,
+            intentHash: parsed.args.intentHash,
+            signer: parsed.args.signer,
+            txId: parsed.args.txId,
+          },
+        ];
+      }
+
+      return [{ name: parsed.name }];
+    } catch (_error) {
+      return [];
+    }
+  });
+
+const maxTotalFee = parseEther('0.083');
+const msgValue = params.userValue + maxTotalFee;
+
+const directTx = await shim.addTransaction(params, { value: msgValue });
+const directReceipt = await directTx.wait();
+
+const feeConfigHash = await shim.hashFeeConfig(params);
+const nonce = await gateway.nonces(params.sender);
+const domain = {
+  name: 'GenLayerIntent',
+  version: '0.1',
+  chainId: deployment.chainId,
+  verifyingContract: deployment.contracts.gateway.address,
+};
+const types = {
+  GenLayerIntent: [
+    { name: 'sender', type: 'address' },
+    { name: 'recipient', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'txDataHash', type: 'bytes32' },
+    { name: 'numInitialValidators', type: 'uint256' },
+    { name: 'maxRotations', type: 'uint256' },
+    { name: 'validUntil', type: 'uint256' },
+    { name: 'maxTotalFee', type: 'uint256' },
+    { name: 'feeConfigHash', type: 'bytes32' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+};
+const value = {
+  sender: params.sender,
+  recipient: params.recipient,
+  value: params.userValue,
+  txDataHash: keccak256(params.txCalldata),
+  numInitialValidators: params.numOfInitialValidators,
+  maxRotations: params.maxRotations,
+  validUntil: params.validUntil,
+  maxTotalFee,
+  feeConfigHash,
+  nonce,
+  deadline: params.validUntil,
+};
+const signature = await wallet.signTypedData(domain, types, value);
+const gatewayTx = await gateway.submitIntent(
+  params,
+  maxTotalFee,
+  nonce,
+  params.validUntil,
+  signature,
+  { value: msgValue },
+);
+const gatewayReceipt = await gatewayTx.wait();
+
+console.log(
+  JSON.stringify(
+    {
+      direct: {
+        txHash: directTx.hash,
+        events: parseKnownEvents(directReceipt),
+      },
+      gateway: {
+        txHash: gatewayTx.hash,
+        signature,
+        events: parseKnownEvents(gatewayReceipt),
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/harness/src/GenLayerFeeShim.sol
+++ b/packages/harness/src/GenLayerFeeShim.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract GenLayerFeeShim {
+    uint256 public transactionCount;
+
+    struct FeesDistribution {
+        uint256 leaderTimeoutFee;
+        uint256 validatorsTimeoutFee;
+        uint256 appealRounds;
+        uint256 rollupUnifiedBudgetPerRound;
+        uint256 rollupUnifiedConsumed;
+        uint256 totalMessageFees;
+        uint256[] rotations;
+        uint256 maxPriceGenPerTimeUnit;
+    }
+
+    struct MessageFeeParams {
+        uint256 leaderTimeunitsAllocation;
+        uint256 validatorTimeunitsAllocation;
+        uint256 appealRounds;
+        uint256 rollupUnifiedBudgetPerRound;
+        uint256[] rotations;
+    }
+
+    struct MessageFeeAllocationNode {
+        uint256 parentIndex;
+        address recipient;
+        bytes4 functionSelector;
+        uint256 budget;
+        MessageFeeParams feeParams;
+    }
+
+    struct AddTransactionParams {
+        address sender;
+        address recipient;
+        uint256 numOfInitialValidators;
+        uint256 maxRotations;
+        uint256 validUntil;
+        uint256 saltNonce;
+        uint256 userValue;
+        FeesDistribution feesDistribution;
+        bytes txCalldata;
+        MessageFeeAllocationNode[] messageAllocations;
+    }
+
+    struct TransactionRecord {
+        address sender;
+        address submittedBy;
+        address recipient;
+        uint256 userValue;
+        uint256 msgValue;
+        bytes32 feeConfigHash;
+        bytes32 txCalldataHash;
+        uint256 createdAt;
+    }
+
+    mapping(bytes32 txId => TransactionRecord record) public transactions;
+
+    event GenLayerTransactionCreated(
+        bytes32 indexed txId,
+        address indexed sender,
+        address indexed recipient,
+        bytes32 feeConfigHash,
+        uint256 userValue,
+        uint256 msgValue
+    );
+
+    event FeeConfigSubmitted(
+        bytes32 indexed txId,
+        uint256 numOfInitialValidators,
+        uint256 maxRotations,
+        uint256 appealRounds,
+        uint256 rotationsCount,
+        uint256 messageAllocationsCount,
+        uint256 maxPriceGenPerTimeUnit,
+        bytes32 txCalldataHash
+    );
+
+    function addTransaction(
+        AddTransactionParams calldata params
+    ) external payable returns (bytes32 txId) {
+        require(params.sender != address(0), "GENLAYER_SHIM_ZERO_SENDER");
+        require(params.validUntil >= block.timestamp, "GENLAYER_SHIM_EXPIRED");
+        require(msg.value >= params.userValue, "GENLAYER_SHIM_VALUE_TOO_LOW");
+
+        bytes32 feeConfigHash = hashFeeConfig(params);
+        bytes32 txCalldataHash = keccak256(params.txCalldata);
+
+        transactionCount += 1;
+        txId = keccak256(
+            abi.encode(
+                block.chainid,
+                address(this),
+                transactionCount,
+                params.sender,
+                params.recipient,
+                params.saltNonce,
+                txCalldataHash,
+                feeConfigHash
+            )
+        );
+
+        transactions[txId] = TransactionRecord({
+            sender: params.sender,
+            submittedBy: msg.sender,
+            recipient: params.recipient,
+            userValue: params.userValue,
+            msgValue: msg.value,
+            feeConfigHash: feeConfigHash,
+            txCalldataHash: txCalldataHash,
+            createdAt: block.timestamp
+        });
+
+        emit GenLayerTransactionCreated(
+            txId,
+            params.sender,
+            params.recipient,
+            feeConfigHash,
+            params.userValue,
+            msg.value
+        );
+
+        emit FeeConfigSubmitted(
+            txId,
+            params.numOfInitialValidators,
+            params.maxRotations,
+            params.feesDistribution.appealRounds,
+            params.feesDistribution.rotations.length,
+            params.messageAllocations.length,
+            params.feesDistribution.maxPriceGenPerTimeUnit,
+            txCalldataHash
+        );
+    }
+
+    function hashFeeConfig(
+        AddTransactionParams calldata params
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(params.feesDistribution, params.messageAllocations));
+    }
+}

--- a/packages/harness/src/GenLayerIntentGateway.sol
+++ b/packages/harness/src/GenLayerIntentGateway.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { GenLayerFeeShim } from "./GenLayerFeeShim.sol";
+
+contract GenLayerIntentGateway {
+    GenLayerFeeShim public immutable SHIM;
+
+    mapping(address signer => uint256 nonce) public nonces;
+
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+    bytes32 private constant GENLAYER_INTENT_TYPEHASH =
+        keccak256(
+            "GenLayerIntent(address sender,address recipient,uint256 value,bytes32 txDataHash,uint256 numInitialValidators,uint256 maxRotations,uint256 validUntil,uint256 maxTotalFee,bytes32 feeConfigHash,uint256 nonce,uint256 deadline)"
+        );
+    bytes32 private constant NAME_HASH = keccak256("GenLayerIntent");
+    bytes32 private constant VERSION_HASH = keccak256("0.1");
+
+    event IntentSubmitted(
+        bytes32 indexed intentHash,
+        address indexed signer,
+        bytes32 indexed txId,
+        uint256 maxTotalFee,
+        uint256 msgValue
+    );
+
+    constructor(address shimAddress) {
+        require(shimAddress != address(0), "GENLAYER_GATEWAY_ZERO_SHIM");
+        SHIM = GenLayerFeeShim(shimAddress);
+    }
+
+    function submitIntent(
+        GenLayerFeeShim.AddTransactionParams calldata params,
+        uint256 maxTotalFee,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) external payable returns (bytes32 txId) {
+        require(block.timestamp <= deadline, "GENLAYER_GATEWAY_EXPIRED");
+        require(nonce == nonces[params.sender], "GENLAYER_GATEWAY_BAD_NONCE");
+        require(msg.value >= params.userValue, "GENLAYER_GATEWAY_VALUE_TOO_LOW");
+        require(
+            msg.value <= params.userValue + maxTotalFee,
+            "GENLAYER_GATEWAY_VALUE_TOO_HIGH"
+        );
+
+        bytes32 feeConfigHash = SHIM.hashFeeConfig(params);
+        bytes32 txDataHash = keccak256(params.txCalldata);
+        bytes32 intentHash = hashIntent(
+            params.sender,
+            params.recipient,
+            params.userValue,
+            txDataHash,
+            params.numOfInitialValidators,
+            params.maxRotations,
+            params.validUntil,
+            maxTotalFee,
+            feeConfigHash,
+            nonce,
+            deadline
+        );
+
+        require(
+            recoverSigner(intentHash, signature) == params.sender,
+            "GENLAYER_GATEWAY_BAD_SIGNATURE"
+        );
+
+        nonces[params.sender] = nonce + 1;
+        txId = SHIM.addTransaction{ value: msg.value }(params);
+
+        emit IntentSubmitted(intentHash, params.sender, txId, maxTotalFee, msg.value);
+    }
+
+    function hashIntent(
+        address sender,
+        address recipient,
+        uint256 value,
+        bytes32 txDataHash,
+        uint256 numInitialValidators,
+        uint256 maxRotations,
+        uint256 validUntil,
+        uint256 maxTotalFee,
+        bytes32 feeConfigHash,
+        uint256 nonce,
+        uint256 deadline
+    ) public view returns (bytes32) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                GENLAYER_INTENT_TYPEHASH,
+                sender,
+                recipient,
+                value,
+                txDataHash,
+                numInitialValidators,
+                maxRotations,
+                validUntil,
+                maxTotalFee,
+                feeConfigHash,
+                nonce,
+                deadline
+            )
+        );
+
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator(), structHash));
+    }
+
+    function domainSeparator() public view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    EIP712_DOMAIN_TYPEHASH,
+                    NAME_HASH,
+                    VERSION_HASH,
+                    block.chainid,
+                    address(this)
+                )
+            );
+    }
+
+    function recoverSigner(
+        bytes32 digest,
+        bytes calldata signature
+    ) public pure returns (address) {
+        require(signature.length == 65, "GENLAYER_GATEWAY_BAD_SIG_LENGTH");
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 0x20))
+            v := byte(0, calldataload(add(signature.offset, 0x40)))
+        }
+
+        if (v < 27) {
+            v += 27;
+        }
+
+        require(v == 27 || v == 28, "GENLAYER_GATEWAY_BAD_SIG_V");
+        return ecrecover(digest, v, r, s);
+    }
+}

--- a/packages/site/.gitignore
+++ b/packages/site/.gitignore
@@ -1,0 +1,2 @@
+.cache/
+public/

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -9,7 +9,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "start": "GATSBY_TELEMETRY_DISABLED=1 gatsby develop"
   },
   "browserslist": {
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@metamask/providers": "^16.0.0",
+    "ethers": "^6.13.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",

--- a/packages/site/src/hooks/index.ts
+++ b/packages/site/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './MetamaskContext';
 export * from './useInvokeSnap';
+export * from './useEip6963Providers';
 export * from './useMetaMask';
 export * from './useRequest';
 export * from './useRequestSnap';

--- a/packages/site/src/hooks/useEip6963Providers.ts
+++ b/packages/site/src/hooks/useEip6963Providers.ts
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useState } from 'react';
+
+type Eip6963ProviderInfo = {
+  uuid: string;
+  name: string;
+  icon?: string;
+  rdns?: string;
+};
+
+export type Eip6963ProviderDetail = {
+  info: Eip6963ProviderInfo;
+  provider: {
+    request?: (args: {
+      method: string;
+      params?: unknown[];
+    }) => Promise<unknown>;
+    isMetaMask?: boolean;
+  };
+};
+
+type Eip6963AnnounceEvent = CustomEvent<Eip6963ProviderDetail>;
+
+const KNOWN_CLEAR_SIGNING_RDNS = ['com.ledger'];
+
+export const isKnownClearSigningWallet = (
+  provider?: Eip6963ProviderDetail,
+): boolean => {
+  if (!provider) {
+    return false;
+  }
+
+  const rdns = provider.info.rdns?.toLowerCase() ?? '';
+  const walletName = provider.info.name.toLowerCase();
+
+  return (
+    KNOWN_CLEAR_SIGNING_RDNS.some((known) => rdns.includes(known)) ||
+    walletName.includes('ledger')
+  );
+};
+
+export const useEip6963Providers = () => {
+  const [providers, setProviders] = useState<Eip6963ProviderDetail[]>([]);
+
+  useEffect(() => {
+    const onProvider = (providerEvent: Event) => {
+      const announcedProvider = (providerEvent as Eip6963AnnounceEvent).detail;
+
+      setProviders((currentProviders) => {
+        const exists = currentProviders.some(
+          (provider) => provider.info.uuid === announcedProvider.info.uuid,
+        );
+
+        if (exists) {
+          return currentProviders;
+        }
+
+        return [...currentProviders, announcedProvider];
+      });
+    };
+
+    window.addEventListener('eip6963:announceProvider', onProvider);
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+
+    return () => {
+      window.removeEventListener('eip6963:announceProvider', onProvider);
+    };
+  }, []);
+
+  return useMemo(
+    () => ({
+      providers,
+      clearSigningProvider: providers.find(isKnownClearSigningWallet),
+    }),
+    [providers],
+  );
+};

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -1,204 +1,1310 @@
+import { useMemo, useState } from 'react';
 import styled from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
 
 import {
   ConnectButton,
   InstallFlaskButton,
   ReconnectButton,
-  SendHelloButton,
-  Card,
 } from '../components';
 import { defaultSnapOrigin } from '../config';
-import { contractData } from '../config/contractData';
 import {
+  useEip6963Providers,
   useMetaMask,
   useMetaMaskContext,
-  useRequestSnap,
   useRequest,
+  useRequestSnap,
 } from '../hooks';
+import {
+  buildGatewayNonceCalldata,
+  buildGatewaySubmissionCalldata,
+  buildTransaction,
+  decodeGatewayNonceResult,
+  formatGen,
+  isUsableAddress,
+  makeDefaultForm,
+  parseHarnessReceiptEvents,
+  shortHex,
+  stringifyBigints,
+} from '../prototype/transaction';
+import type {
+  FeeProfile,
+  PrototypeForm,
+  RpcReceiptLog,
+  ValidityUnit,
+} from '../prototype/transaction';
 import { isLocalSnap, shouldDisplayReconnectButton } from '../utils';
 
-const Container = styled.div`
+const Container = styled.main`
+  flex: 1;
+  width: min(128rem, calc(100% - 4.8rem));
+  margin: 3.2rem auto 6.4rem;
+
+  ${({ theme }) => theme.mediaQueries.small} {
+    width: calc(100% - 2.4rem);
+    margin-top: 1.6rem;
+    margin-bottom: 3.2rem;
+  }
+`;
+
+const HeaderBlock = styled.section`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2.4rem;
+  align-items: start;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border?.default};
+  padding-bottom: 2.4rem;
+
+  ${({ theme }) => theme.mediaQueries.small} {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const Title = styled.h1`
+  font-size: 3.2rem;
+  line-height: 1.1;
+  margin: 0 0 0.8rem;
+
+  ${({ theme }) => theme.mediaQueries.small} {
+    font-size: 2.8rem;
+  }
+`;
+
+const Subtitle = styled.p`
+  color: ${({ theme }) => theme.colors.text?.alternative};
+  margin: 0;
+  max-width: 78rem;
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: minmax(34rem, 42rem) minmax(0, 1fr);
+  gap: 2.4rem;
+  margin-top: 2.4rem;
+
+  ${({ theme }) => theme.mediaQueries.small} {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const Panel = styled.section`
+  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.card?.default};
+  padding: 1.6rem;
+`;
+
+const PanelTitle = styled.h2`
+  font-size: 1.8rem;
+  margin: 0 0 1.2rem;
+`;
+
+const FieldGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+
+  ${({ theme }) => theme.mediaQueries.small} {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const Field = styled.label`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  flex: 1;
-  margin-top: 7.6rem;
-  margin-bottom: 7.6rem;
-  ${({ theme }) => theme.mediaQueries.small} {
-    padding-left: 2.4rem;
-    padding-right: 2.4rem;
-    margin-top: 2rem;
-    margin-bottom: 2rem;
-    width: auto;
-  }
-`;
-
-const Heading = styled.h1`
-  margin-top: 0;
-  margin-bottom: 2.4rem;
-  text-align: center;
-`;
-
-const Span = styled.span`
-  color: ${(props) => props.theme.colors.primary?.default};
-`;
-
-const CardContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  max-width: 64.8rem;
-  width: 100%;
-  height: 100%;
-  margin-top: 1.5rem;
-`;
-
-const Notice = styled.div`
-  background-color: ${({ theme }) => theme.colors.background?.alternative};
-  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  gap: 0.6rem;
   color: ${({ theme }) => theme.colors.text?.alternative};
-  border-radius: ${({ theme }) => theme.radii.default};
-  padding: 2.4rem;
-  margin-top: 2.4rem;
-  max-width: 60rem;
-  width: 100%;
+  font-size: ${({ theme }) => theme.fontSizes.small};
+`;
 
-  & > * {
-    margin: 0;
+const FullField = styled(Field)`
+  grid-column: 1 / -1;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.background?.default};
+  color: ${({ theme }) => theme.colors.text?.default};
+  min-height: 4rem;
+  padding: 0.9rem 1rem;
+  font: inherit;
+`;
+
+const Select = styled.select`
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.background?.default};
+  color: ${({ theme }) => theme.colors.text?.default};
+  min-height: 4rem;
+  padding: 0.9rem 1rem;
+  font: inherit;
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+`;
+
+const Stack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;
+
+const routeBorderColor = (
+  tone: 'good' | 'warn' | 'neutral',
+  theme: DefaultTheme,
+): string => {
+  if (tone === 'good') {
+    return '#188038';
   }
+  if (tone === 'warn') {
+    return theme.colors.error?.default ?? '#d73a49';
+  }
+  return theme.colors.border?.default ?? '#d0d7de';
+};
+
+const routeBackgroundColor = (tone: 'good' | 'warn' | 'neutral'): string => {
+  if (tone === 'good') {
+    return '#18803814';
+  }
+  if (tone === 'warn') {
+    return '#d73a4919';
+  }
+  return 'transparent';
+};
+
+const RouteBadge = styled.div<{ tone: 'good' | 'warn' | 'neutral' }>`
+  border-radius: 8px;
+  padding: 1.2rem;
+  border: 1px solid ${({ tone, theme }) => routeBorderColor(tone, theme)};
+  background: ${({ tone }) => routeBackgroundColor(tone)};
+`;
+
+const BadgeTitle = styled.div`
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+`;
+
+const Muted = styled.span`
+  color: ${({ theme }) => theme.colors.text?.alternative};
+`;
+
+const StatGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.2rem;
+
   ${({ theme }) => theme.mediaQueries.small} {
-    margin-top: 1.2rem;
-    padding: 1.6rem;
+    grid-template-columns: 1fr 1fr;
   }
+`;
+
+const Stat = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  border-radius: 8px;
+  padding: 1rem;
+  min-width: 0;
+`;
+
+const StatLabel = styled.div`
+  color: ${({ theme }) => theme.colors.text?.alternative};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+`;
+
+const StatValue = styled.div`
+  font-weight: 700;
+  margin-top: 0.4rem;
+  overflow-wrap: anywhere;
+`;
+
+const CodeBlock = styled.pre`
+  margin: 0;
+  max-height: 28rem;
+  overflow: auto;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.colors.background?.alternative};
+  padding: 1.2rem;
+  font-family: ${({ theme }) => theme.fonts.code};
+  font-size: 1.2rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+`;
+
+const CheckboxLabel = styled.label`
+  display: inline-flex;
+  gap: 0.8rem;
+  align-items: center;
+  color: ${({ theme }) => theme.colors.text?.alternative};
 `;
 
 const ErrorMessage = styled.div`
-  background-color: ${({ theme }) => theme.colors.error?.muted};
   border: 1px solid ${({ theme }) => theme.colors.error?.default};
+  background: ${({ theme }) => theme.colors.error?.muted};
   color: ${({ theme }) => theme.colors.error?.alternative};
-  border-radius: ${({ theme }) => theme.radii.default};
-  padding: 2.4rem;
-  margin-bottom: 2.4rem;
-  margin-top: 2.4rem;
-  max-width: 60rem;
-  width: 100%;
-  ${({ theme }) => theme.mediaQueries.small} {
-    padding: 1.6rem;
-    margin-bottom: 1.2rem;
-    margin-top: 1.2rem;
-    max-width: 100%;
-  }
+  border-radius: 8px;
+  padding: 1.2rem;
 `;
 
+const Notice = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.border?.default};
+  background: ${({ theme }) => theme.colors.background?.alternative};
+  border-radius: 8px;
+  padding: 1.2rem;
+`;
+
+const PROFILE_PRESETS: Record<
+  FeeProfile,
+  Partial<
+    Pick<
+      PrototypeForm,
+      | 'leaderTimeoutFee'
+      | 'validatorsTimeoutFee'
+      | 'appealRounds'
+      | 'rollupUnifiedBudgetPerRound'
+      | 'totalMessageFees'
+      | 'rotations'
+      | 'maxPriceGenPerTimeUnit'
+    >
+  >
+> = {
+  low: {
+    leaderTimeoutFee: '0.0005',
+    validatorsTimeoutFee: '0.001',
+    appealRounds: '0',
+    rollupUnifiedBudgetPerRound: '0.004',
+    totalMessageFees: '0',
+    rotations: '0',
+    maxPriceGenPerTimeUnit: '110',
+  },
+  standard: {
+    leaderTimeoutFee: '0.001',
+    validatorsTimeoutFee: '0.002',
+    appealRounds: '1',
+    rollupUnifiedBudgetPerRound: '0.01',
+    totalMessageFees: '0.02',
+    rotations: '0,1',
+    maxPriceGenPerTimeUnit: '120',
+  },
+  high: {
+    leaderTimeoutFee: '0.002',
+    validatorsTimeoutFee: '0.004',
+    appealRounds: '2',
+    rollupUnifiedBudgetPerRound: '0.025',
+    totalMessageFees: '0.05',
+    rotations: '0,1,1',
+    maxPriceGenPerTimeUnit: '150',
+  },
+  custom: {},
+};
+
+type Route = {
+  label: string;
+  tone: 'good' | 'warn' | 'neutral';
+  description: string;
+};
+
+type HarnessDeployment = {
+  chainId: number;
+  rpcUrl: string;
+  deployedAt: string;
+  contracts: {
+    shim: {
+      address: string;
+      txHash: string | null;
+    };
+    gateway: {
+      address: string;
+      txHash: string | null;
+    };
+  };
+};
+
+type RpcTransactionReceipt = {
+  transactionHash: string;
+  status?: string;
+  blockNumber?: string;
+  logs: RpcReceiptLog[];
+};
+
+const LOCAL_HARNESS_CHAIN_ID = 31337;
+const LOCAL_HARNESS_CHAIN_ID_HEX = '0x7a69';
+const LOCAL_HARNESS_RPC_URL = 'http://127.0.0.1:8545';
+
+const sleep = async (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const validityUnitSeconds: Record<ValidityUnit, number> = {
+  minutes: 60,
+  hours: 60 * 60,
+  days: 24 * 60 * 60,
+};
+
+const parsePositiveNumber = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  return parsed;
+};
+
+const buildValidUntil = (
+  duration: string,
+  unit: ValidityUnit,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): string =>
+  String(
+    Math.floor(
+      nowSeconds + parsePositiveNumber(duration) * validityUnitSeconds[unit],
+    ),
+  );
+
+const formatUnixSeconds = (value: string): string => {
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 'Invalid timestamp';
+  }
+
+  return new Date(parsed * 1000).toLocaleString();
+};
+
+const getValidityWarning = (form: PrototypeForm): string | null => {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const validUntil = Number.parseInt(form.validUntil, 10);
+  const maxSeconds = parsePositiveNumber(form.maxValidUntilDays) * 24 * 60 * 60;
+
+  if (!Number.isFinite(validUntil) || validUntil <= nowSeconds) {
+    return 'This transaction is already expired or has an invalid expiry.';
+  }
+
+  if (maxSeconds > 0 && validUntil - nowSeconds > maxSeconds) {
+    return `Expiry exceeds the configured ${form.maxValidUntilDays}-day maximum.`;
+  }
+
+  return null;
+};
+
+const getQueueWarning = (form: PrototypeForm): string | null => {
+  const depth = parsePositiveNumber(form.queueDepth);
+  const max = parsePositiveNumber(form.maxQueueSize);
+
+  if (max <= 0) {
+    return 'Queue max is not configured.';
+  }
+
+  if (depth >= max) {
+    return 'Recipient queue is full; submission should be blocked.';
+  }
+
+  if (depth / max >= 0.8) {
+    return 'Recipient queue is over 80% full.';
+  }
+
+  return null;
+};
+
+const buildRoute = ({
+  hasClearSigning,
+  hasSnap,
+  hasSmartAccountHint,
+}: {
+  hasClearSigning: boolean;
+  hasSnap: boolean;
+  hasSmartAccountHint: boolean;
+}): Route => {
+  if (hasClearSigning) {
+    return {
+      label: 'Verified direct addTransaction',
+      tone: 'good',
+      description:
+        'Use ConsensusMainWithFees.addTransaction directly. Wallet is treated as clear-signing capable.',
+    };
+  }
+
+  if (hasSnap) {
+    return {
+      label: 'Snap-verified direct addTransaction',
+      tone: 'good',
+      description:
+        'Use the direct consensus call and let the GenLayer Snap decode the fee struct in MetaMask Desktop.',
+    };
+  }
+
+  if (hasSmartAccountHint) {
+    return {
+      label: 'Intent or smart-account gateway path',
+      tone: 'neutral',
+      description:
+        'Use the EIP-712 intent and submit through a relayer, paymaster, or account abstraction flow.',
+    };
+  }
+
+  return {
+    label: 'Unverified wallet route',
+    tone: 'warn',
+    description:
+      'Do not silently send high-value transactions. Use gateway intent, install Snap, or switch to a clear-signing wallet.',
+  };
+};
+
+const includesSmartAccountHint = (capabilities: unknown): boolean => {
+  const serialized = JSON.stringify(capabilities ?? {}).toLowerCase();
+  return (
+    serialized.includes('paymaster') ||
+    serialized.includes('atomic') ||
+    serialized.includes('wallet_sendcalls') ||
+    serialized.includes('smart')
+  );
+};
+
 const Index = () => {
+  const [form, setForm] = useState<PrototypeForm>(() => makeDefaultForm());
+  const [accounts, setAccounts] = useState<string[]>([]);
+  const [capabilities, setCapabilities] = useState<unknown>(null);
+  const [sendResult, setSendResult] = useState<string>('');
+  const [signResult, setSignResult] = useState<string>('');
+  const [harnessStatus, setHarnessStatus] = useState<string>('');
+  const [assumeClearSigning, setAssumeClearSigning] = useState(false);
+
   const { error } = useMetaMaskContext();
   const { isFlask, snapsDetected, installedSnap } = useMetaMask();
   const requestSnap = useRequestSnap();
   const request = useRequest();
+  const { providers, clearSigningProvider } = useEip6963Providers();
+
+  const builtResult = useMemo(() => {
+    try {
+      return { built: buildTransaction(form), error: null };
+    } catch (buildError) {
+      return { built: null, error: buildError as Error };
+    }
+  }, [form]);
+
+  const route = buildRoute({
+    hasClearSigning: assumeClearSigning || Boolean(clearSigningProvider),
+    hasSnap: Boolean(installedSnap),
+    hasSmartAccountHint: includesSmartAccountHint(capabilities),
+  });
+  const validityWarning = getValidityWarning(form);
+  const queueWarning = getQueueWarning(form);
 
   const isMetaMaskReady = isLocalSnap(defaultSnapOrigin)
     ? isFlask
     : snapsDetected;
 
-  const handleRequestClick = async () => {
-    const [from] = (await request({
-      method: 'eth_requestAccounts',
-      params: [],
-    })) as any;
+  const updateForm = <Key extends keyof PrototypeForm>(
+    key: Key,
+    value: PrototypeForm[Key],
+  ) => {
+    setForm((current) => ({ ...current, [key]: value }));
+  };
+
+  const applyProfile = (profile: FeeProfile) => {
+    setForm((current) => ({
+      ...current,
+      profile,
+      ...PROFILE_PRESETS[profile],
+    }));
+  };
+
+  const applyValidityDuration = (
+    duration: string,
+    unit: ValidityUnit = form.validityUnit,
+  ) => {
+    setForm((current) => ({
+      ...current,
+      validityDuration: duration,
+      validityUnit: unit,
+      validUntil: buildValidUntil(duration, unit),
+    }));
+  };
+
+  const waitForReceipt = async (
+    txHash: string,
+  ): Promise<RpcTransactionReceipt | null> => {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const receipt = (await request({
+        method: 'eth_getTransactionReceipt',
+        params: [txHash],
+      })) as RpcTransactionReceipt | null;
+
+      if (receipt) {
+        return receipt;
+      }
+
+      await sleep(1000);
+    }
+
+    return null;
+  };
+
+  const loadLocalHarness = async () => {
     try {
-      const response = await request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from,
-            to: null,
-            value: '0x0',
-            data: contractData,
-          },
-        ],
+      setHarnessStatus('Loading local harness deployment...');
+      const response = await fetch('/harness.local.json', {
+        cache: 'no-store',
       });
-      console.log(response);
-    } catch (requestError) {
-      console.log(requestError);
+
+      if (!response.ok) {
+        setHarnessStatus(
+          'No local harness deployment found. Start Anvil, then run yarn workspace harness deploy.',
+        );
+        return;
+      }
+
+      const deployment = (await response.json()) as HarnessDeployment;
+      setForm((current) => ({
+        ...current,
+        chainId: String(deployment.chainId),
+        consensusAddress: deployment.contracts.shim.address,
+        gatewayAddress: deployment.contracts.gateway.address,
+        validityDuration: '1',
+        validityUnit: 'hours',
+        validUntil: buildValidUntil('1', 'hours'),
+        gatewayNonce: '0',
+      }));
+      setHarnessStatus(
+        `Loaded ${deployment.contracts.shim.address} and ${deployment.contracts.gateway.address}`,
+      );
+    } catch (loadError) {
+      setHarnessStatus((loadError as Error).message);
     }
   };
+
+  const addLocalHarnessNetwork = async () => {
+    await request({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: LOCAL_HARNESS_CHAIN_ID_HEX,
+          chainName: 'GenLayer Local Harness',
+          nativeCurrency: {
+            name: 'GEN Token',
+            symbol: 'GEN',
+            decimals: 18,
+          },
+          rpcUrls: [LOCAL_HARNESS_RPC_URL],
+        },
+      ],
+    });
+  };
+
+  const connectWallet = async () => {
+    const requestedAccounts = (await request({
+      method: 'eth_requestAccounts',
+      params: [],
+    })) as string[] | null;
+
+    if (requestedAccounts?.length) {
+      setAccounts(requestedAccounts);
+      setForm((current) => ({
+        ...current,
+        sender: requestedAccounts[0] ?? current.sender,
+      }));
+    }
+  };
+
+  const detectCapabilities = async () => {
+    const account = accounts[0];
+    const result = await request({
+      method: 'wallet_getCapabilities',
+      params: account ? [account] : [],
+    });
+
+    setCapabilities(result);
+  };
+
+  const refreshGatewayNonce = async () => {
+    const account = accounts[0];
+
+    if (!account || !isUsableAddress(form.gatewayAddress)) {
+      return;
+    }
+
+    const result = (await request({
+      method: 'eth_call',
+      params: [
+        {
+          to: form.gatewayAddress,
+          data: buildGatewayNonceCalldata(account),
+        },
+        'latest',
+      ],
+    })) as string | null;
+
+    if (result) {
+      updateForm('gatewayNonce', decodeGatewayNonceResult(result));
+    }
+  };
+
+  const sendDirectTransaction = async () => {
+    if (!builtResult.built || !accounts[0]) {
+      return;
+    }
+
+    setSendResult('Submitting direct transaction...');
+
+    const response = (await request({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: accounts[0],
+          ...builtResult.built.txRequest,
+        },
+      ],
+    })) as string | null;
+
+    if (!response) {
+      return;
+    }
+
+    setSendResult(`Waiting for receipt: ${response}`);
+    const receipt = await waitForReceipt(response);
+    const parsedEvents = receipt ? parseHarnessReceiptEvents(receipt.logs) : [];
+
+    setSendResult(
+      stringifyBigints({
+        txHash: response,
+        receiptStatus: receipt?.status ?? 'pending',
+        blockNumber: receipt?.blockNumber,
+        parsedEvents,
+      }),
+    );
+  };
+
+  const signGatewayIntent = async () => {
+    if (!builtResult.built || !accounts[0]) {
+      return;
+    }
+
+    const payload = {
+      domain: builtResult.built.intent.domain,
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        ...builtResult.built.intent.types,
+      },
+      primaryType: 'GenLayerIntent',
+      message: builtResult.built.intent.value,
+    };
+
+    setSignResult('Requesting typed-data signature...');
+
+    const signature = (await request({
+      method: 'eth_signTypedData_v4',
+      params: [accounts[0], stringifyBigints(payload)],
+    })) as string | null;
+
+    if (!signature) {
+      return;
+    }
+
+    setSignResult('Submitting signed intent through gateway...');
+
+    const txHash = (await request({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: accounts[0],
+          to: form.gatewayAddress,
+          data: buildGatewaySubmissionCalldata(form, signature),
+          value: builtResult.built.txRequest.value,
+        },
+      ],
+    })) as string | null;
+
+    if (!txHash) {
+      setSignResult(
+        stringifyBigints({
+          signature,
+          submitted: false,
+        }),
+      );
+      return;
+    }
+
+    const receipt = await waitForReceipt(txHash);
+    const parsedEvents = receipt ? parseHarnessReceiptEvents(receipt.logs) : [];
+
+    setSignResult(
+      stringifyBigints({
+        signature,
+        txHash,
+        receiptStatus: receipt?.status ?? 'pending',
+        blockNumber: receipt?.blockNumber,
+        parsedEvents,
+      }),
+    );
+
+    setForm((current) => ({
+      ...current,
+      gatewayNonce: String(
+        Number.parseInt(current.gatewayNonce || '0', 10) + 1,
+      ),
+    }));
+  };
+
+  const runAsync = (action: () => Promise<unknown>) => () => {
+    action().catch((actionError: unknown) => {
+      setHarnessStatus(
+        actionError instanceof Error
+          ? actionError.message
+          : String(actionError),
+      );
+    });
+  };
+
+  const canSendDirect =
+    Boolean(accounts[0]) &&
+    Boolean(builtResult.built) &&
+    isUsableAddress(form.consensusAddress);
+  const canSignIntent =
+    Boolean(accounts[0]) &&
+    Boolean(builtResult.built) &&
+    isUsableAddress(form.gatewayAddress);
+
   return (
     <Container>
-      <Heading>
-        Welcome to <Span>Genlayer Snap</Span>
-      </Heading>
-      <CardContainer>
-        {error && (
-          <ErrorMessage>
-            <b>An error happened:</b> {error.message}
-          </ErrorMessage>
-        )}
-        {!isMetaMaskReady && (
-          <Card
-            content={{
-              title: 'Install',
-              description:
-                'Snaps is pre-release software only available in MetaMask Flask, a canary distribution for developers with access to upcoming features.',
-              button: <InstallFlaskButton />,
-            }}
-            fullWidth
-          />
-        )}
-        {!installedSnap && (
-          <Card
-            content={{
-              title: 'Connect',
-              description:
-                'Get started by connecting to and installing the example snap.',
-              button: (
-                <ConnectButton
-                  onClick={requestSnap}
-                  disabled={!isMetaMaskReady}
+      <HeaderBlock>
+        <div>
+          <Title>GenLayer Transaction Prototype</Title>
+          <Subtitle>
+            Configure a fee-aware GenLayer transaction, inspect the exact
+            consensus calldata, then route it through clear signing, Snap, or an
+            intent gateway fallback.
+          </Subtitle>
+        </div>
+        <Row>
+          {!isMetaMaskReady && <InstallFlaskButton />}
+          {isMetaMaskReady && !installedSnap && (
+            <ConnectButton onClick={runAsync(requestSnap)}>
+              Install Snap
+            </ConnectButton>
+          )}
+          {shouldDisplayReconnectButton(installedSnap) && (
+            <ReconnectButton onClick={runAsync(requestSnap)}>
+              Reconnect Snap
+            </ReconnectButton>
+          )}
+          <button onClick={runAsync(connectWallet)} type="button">
+            Connect wallet
+          </button>
+        </Row>
+      </HeaderBlock>
+
+      <Grid>
+        <Stack>
+          {error && (
+            <ErrorMessage>
+              <strong>Wallet error:</strong> {error.message}
+            </ErrorMessage>
+          )}
+
+          <Panel>
+            <PanelTitle>1. Security and Fee Policy</PanelTitle>
+            <FieldGrid>
+              <FullField>
+                Profile
+                <Select
+                  value={form.profile}
+                  onChange={(changeEvent) =>
+                    applyProfile(changeEvent.target.value as FeeProfile)
+                  }
+                >
+                  <option value="low">Low</option>
+                  <option value="standard">Standard</option>
+                  <option value="high">High</option>
+                  <option value="custom">Custom</option>
+                </Select>
+              </FullField>
+              <Field>
+                Initial validators
+                <Input
+                  value={form.numInitialValidators}
+                  onChange={(changeEvent) =>
+                    updateForm('numInitialValidators', changeEvent.target.value)
+                  }
                 />
-              ),
-            }}
-            disabled={!isMetaMaskReady}
-          />
-        )}
-        {shouldDisplayReconnectButton(installedSnap) && (
-          <Card
-            content={{
-              title: 'Reconnect',
-              description:
-                'While connected to a local running snap this button will always be displayed in order to update the snap if a change is made.',
-              button: (
-                <ReconnectButton
-                  onClick={requestSnap}
-                  disabled={!installedSnap}
+              </Field>
+              <Field>
+                Max rotations
+                <Input
+                  value={form.maxRotations}
+                  onChange={(changeEvent) =>
+                    updateForm('maxRotations', changeEvent.target.value)
+                  }
                 />
-              ),
-            }}
-            disabled={!installedSnap}
-          />
-        )}
-        <Card
-          content={{
-            title: 'Test Snap',
-            description: 'Send a transaction.',
-            button: <SendHelloButton onClick={handleRequestClick} />,
-          }}
-          // disabled={!installedSnap}
-          fullWidth={
-            isMetaMaskReady &&
-            Boolean(installedSnap) &&
-            !shouldDisplayReconnectButton(installedSnap)
-          }
-        />
-        <Notice>
-          <p>
-            Please note that the <b>snap.manifest.json</b> and{' '}
-            <b>package.json</b> must be located in the server root directory and
-            the bundle must be hosted at the location specified by the location
-            field.
-          </p>
-        </Notice>
-      </CardContainer>
+              </Field>
+              <Field>
+                Appeal rounds
+                <Input
+                  value={form.appealRounds}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm('appealRounds', changeEvent.target.value);
+                  }}
+                />
+              </Field>
+              <Field>
+                Rotations array
+                <Input
+                  value={form.rotations}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm('rotations', changeEvent.target.value);
+                  }}
+                />
+              </Field>
+              <Field>
+                Leader timeout fee
+                <Input
+                  value={form.leaderTimeoutFee}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm('leaderTimeoutFee', changeEvent.target.value);
+                  }}
+                />
+              </Field>
+              <Field>
+                Validator timeout fee
+                <Input
+                  value={form.validatorsTimeoutFee}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm(
+                      'validatorsTimeoutFee',
+                      changeEvent.target.value,
+                    );
+                  }}
+                />
+              </Field>
+              <Field>
+                Rollup budget / round
+                <Input
+                  value={form.rollupUnifiedBudgetPerRound}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm(
+                      'rollupUnifiedBudgetPerRound',
+                      changeEvent.target.value,
+                    );
+                  }}
+                />
+              </Field>
+              <Field>
+                Max GEN/time-unit
+                <Input
+                  value={form.maxPriceGenPerTimeUnit}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm(
+                      'maxPriceGenPerTimeUnit',
+                      changeEvent.target.value,
+                    );
+                  }}
+                />
+              </Field>
+              <Field>
+                Message mode
+                <Select
+                  value={form.messageMode}
+                  onChange={(changeEvent) =>
+                    updateForm(
+                      'messageMode',
+                      changeEvent.target.value as PrototypeForm['messageMode'],
+                    )
+                  }
+                >
+                  <option value="none">None</option>
+                  <option value="mode1">Mode 1: bucket only</option>
+                  <option value="mode2">Mode 2: allocation tree</option>
+                </Select>
+              </Field>
+              <Field>
+                Total message fees
+                <Input
+                  value={form.totalMessageFees}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm('totalMessageFees', changeEvent.target.value);
+                  }}
+                />
+              </Field>
+              {form.messageMode === 'mode2' && (
+                <>
+                  <FullField>
+                    Message recipient
+                    <Input
+                      value={form.messageRecipient}
+                      onChange={(changeEvent) =>
+                        updateForm('messageRecipient', changeEvent.target.value)
+                      }
+                    />
+                  </FullField>
+                  <Field>
+                    Selector
+                    <Input
+                      value={form.messageSelector}
+                      onChange={(changeEvent) =>
+                        updateForm('messageSelector', changeEvent.target.value)
+                      }
+                    />
+                  </Field>
+                  <Field>
+                    Node budget
+                    <Input
+                      value={form.messageBudget}
+                      onChange={(changeEvent) =>
+                        updateForm('messageBudget', changeEvent.target.value)
+                      }
+                    />
+                  </Field>
+                </>
+              )}
+            </FieldGrid>
+          </Panel>
+
+          <Panel>
+            <PanelTitle>2. Transaction Target</PanelTitle>
+            <Notice style={{ marginBottom: '1.2rem' }}>
+              <Row>
+                <button onClick={runAsync(loadLocalHarness)} type="button">
+                  Load local harness
+                </button>
+                <button
+                  onClick={runAsync(addLocalHarnessNetwork)}
+                  type="button"
+                >
+                  Add local chain
+                </button>
+                <button onClick={runAsync(refreshGatewayNonce)} type="button">
+                  Refresh nonce
+                </button>
+              </Row>
+              <p style={{ marginBottom: 0 }}>
+                <Muted>
+                  Local harness expects Anvil chain {LOCAL_HARNESS_CHAIN_ID} and
+                  a generated <code>harness.local.json</code>.
+                </Muted>
+              </p>
+              {harnessStatus && (
+                <CodeBlock style={{ marginTop: '1.2rem' }}>
+                  {harnessStatus}
+                </CodeBlock>
+              )}
+            </Notice>
+            <FieldGrid>
+              <FullField>
+                ConsensusMainWithFees
+                <Input
+                  placeholder="0x..."
+                  value={form.consensusAddress}
+                  onChange={(changeEvent) =>
+                    updateForm('consensusAddress', changeEvent.target.value)
+                  }
+                />
+              </FullField>
+              <FullField>
+                Gateway
+                <Input
+                  placeholder="0x..."
+                  value={form.gatewayAddress}
+                  onChange={(changeEvent) =>
+                    updateForm('gatewayAddress', changeEvent.target.value)
+                  }
+                />
+              </FullField>
+              <Field>
+                Chain ID
+                <Input
+                  value={form.chainId}
+                  onChange={(changeEvent) =>
+                    updateForm('chainId', changeEvent.target.value)
+                  }
+                />
+              </Field>
+              <Field>
+                Method
+                <Input
+                  value={form.methodName}
+                  onChange={(changeEvent) =>
+                    updateForm('methodName', changeEvent.target.value)
+                  }
+                />
+              </Field>
+              <FullField>
+                Recipient
+                <Input
+                  value={form.recipient}
+                  onChange={(changeEvent) =>
+                    updateForm('recipient', changeEvent.target.value)
+                  }
+                />
+              </FullField>
+              <Field>
+                User value
+                <Input
+                  value={form.userValue}
+                  onChange={(changeEvent) =>
+                    updateForm('userValue', changeEvent.target.value)
+                  }
+                />
+              </Field>
+              <Field>
+                Expires in
+                <Input
+                  value={form.validityDuration}
+                  onChange={(changeEvent) =>
+                    applyValidityDuration(changeEvent.target.value)
+                  }
+                />
+              </Field>
+              <Field>
+                Expiry unit
+                <Select
+                  value={form.validityUnit}
+                  onChange={(changeEvent) =>
+                    applyValidityDuration(
+                      form.validityDuration,
+                      changeEvent.target.value as ValidityUnit,
+                    )
+                  }
+                >
+                  <option value="minutes">Minutes</option>
+                  <option value="hours">Hours</option>
+                  <option value="days">Days</option>
+                </Select>
+              </Field>
+              <Field>
+                Max expiry days
+                <Input
+                  value={form.maxValidUntilDays}
+                  onChange={(changeEvent) =>
+                    updateForm('maxValidUntilDays', changeEvent.target.value)
+                  }
+                />
+              </Field>
+              <Field>
+                Gateway nonce
+                <Input
+                  value={form.gatewayNonce}
+                  onChange={(changeEvent) =>
+                    updateForm('gatewayNonce', changeEvent.target.value)
+                  }
+                />
+              </Field>
+              <FullField>
+                Raw validUntil timestamp
+                <Input
+                  value={form.validUntil}
+                  onChange={(changeEvent) =>
+                    updateForm('validUntil', changeEvent.target.value)
+                  }
+                />
+              </FullField>
+              <Field>
+                Queue before you
+                <Input
+                  value={form.queueDepth}
+                  onChange={(changeEvent) =>
+                    updateForm('queueDepth', changeEvent.target.value)
+                  }
+                />
+              </Field>
+              <Field>
+                Max queue size
+                <Input
+                  value={form.maxQueueSize}
+                  onChange={(changeEvent) =>
+                    updateForm('maxQueueSize', changeEvent.target.value)
+                  }
+                />
+              </Field>
+            </FieldGrid>
+            <Notice style={{ marginTop: '1.2rem' }}>
+              <div>
+                <strong>Expiry:</strong> {formatUnixSeconds(form.validUntil)}
+              </div>
+              <div>
+                <strong>Queue:</strong> {form.queueDepth} before you /{' '}
+                {form.maxQueueSize} max
+              </div>
+              {(validityWarning || queueWarning) && (
+                <p style={{ marginBottom: 0 }}>
+                  <Muted>{validityWarning ?? queueWarning}</Muted>
+                </p>
+              )}
+            </Notice>
+          </Panel>
+        </Stack>
+
+        <Stack>
+          <Panel>
+            <PanelTitle>3. Wallet Route</PanelTitle>
+            <RouteBadge tone={route.tone}>
+              <BadgeTitle>{route.label}</BadgeTitle>
+              <Muted>{route.description}</Muted>
+            </RouteBadge>
+            <Row style={{ marginTop: '1.2rem' }}>
+              <CheckboxLabel>
+                <input
+                  checked={assumeClearSigning}
+                  onChange={(changeEvent) =>
+                    setAssumeClearSigning(changeEvent.target.checked)
+                  }
+                  type="checkbox"
+                />
+                Force ERC-7730 route for prototype testing
+              </CheckboxLabel>
+            </Row>
+            <Row style={{ marginTop: '1.2rem' }}>
+              <button onClick={runAsync(connectWallet)} type="button">
+                Connect
+              </button>
+              <button onClick={runAsync(detectCapabilities)} type="button">
+                Detect capabilities
+              </button>
+            </Row>
+            <CodeBlock style={{ marginTop: '1.2rem' }}>
+              {stringifyBigints({
+                accounts,
+                snapInstalled: Boolean(installedSnap),
+                eip6963Providers: providers.map((provider) => ({
+                  name: provider.info.name,
+                  rdns: provider.info.rdns,
+                  clearSigningKnown:
+                    provider.info.uuid === clearSigningProvider?.info.uuid,
+                })),
+                capabilities,
+              })}
+            </CodeBlock>
+          </Panel>
+
+          {builtResult.error && (
+            <ErrorMessage>
+              <strong>Build error:</strong> {builtResult.error.message}
+            </ErrorMessage>
+          )}
+
+          {builtResult.built && (
+            <>
+              <Panel>
+                <PanelTitle>4. Cost Preview</PanelTitle>
+                <StatGrid>
+                  <Stat>
+                    <StatLabel>Consensus fees</StatLabel>
+                    <StatValue>
+                      {formatGen(builtResult.built.estimate.totalFees)} GEN
+                    </StatValue>
+                  </Stat>
+                  <Stat>
+                    <StatLabel>User value</StatLabel>
+                    <StatValue>
+                      {formatGen(builtResult.built.params.userValue)} GEN
+                    </StatValue>
+                  </Stat>
+                  <Stat>
+                    <StatLabel>msg.value</StatLabel>
+                    <StatValue>
+                      {formatGen(builtResult.built.estimate.totalMsgValue)} GEN
+                    </StatValue>
+                  </Stat>
+                  <Stat>
+                    <StatLabel>Fee hash</StatLabel>
+                    <StatValue>
+                      {shortHex(builtResult.built.feeConfigHash)}
+                    </StatValue>
+                  </Stat>
+                </StatGrid>
+              </Panel>
+
+              <Panel>
+                <PanelTitle>5. Generated Payloads</PanelTitle>
+                <Stack>
+                  <div>
+                    <Muted>AddTransactionParams</Muted>
+                    <CodeBlock>
+                      {stringifyBigints(builtResult.built.params)}
+                    </CodeBlock>
+                  </div>
+                  <div>
+                    <Muted>Direct EVM transaction</Muted>
+                    <CodeBlock>
+                      {stringifyBigints({
+                        ...builtResult.built.txRequest,
+                        data: shortHex(builtResult.built.txRequest.data, 18),
+                      })}
+                    </CodeBlock>
+                  </div>
+                  <div>
+                    <Muted>Gateway EIP-712 intent</Muted>
+                    <CodeBlock>
+                      {stringifyBigints(builtResult.built.intent)}
+                    </CodeBlock>
+                  </div>
+                </Stack>
+              </Panel>
+
+              <Panel>
+                <PanelTitle>6. Execute</PanelTitle>
+                <Row>
+                  <button
+                    disabled={!canSendDirect}
+                    onClick={runAsync(sendDirectTransaction)}
+                    type="button"
+                  >
+                    Send direct addTransaction
+                  </button>
+                  <button
+                    disabled={!canSignIntent}
+                    onClick={runAsync(signGatewayIntent)}
+                    type="button"
+                  >
+                    Sign and submit gateway intent
+                  </button>
+                </Row>
+                {!canSendDirect && (
+                  <p>
+                    <Muted>
+                      Set a deployed consensus address and connect a wallet to
+                      enable direct submission.
+                    </Muted>
+                  </p>
+                )}
+                {sendResult && (
+                  <div>
+                    <Muted>Direct tx result</Muted>
+                    <CodeBlock>{sendResult}</CodeBlock>
+                  </div>
+                )}
+                {signResult && (
+                  <div>
+                    <Muted>Intent signature</Muted>
+                    <CodeBlock>{signResult}</CodeBlock>
+                  </div>
+                )}
+              </Panel>
+            </>
+          )}
+        </Stack>
+      </Grid>
     </Container>
   );
 };

--- a/packages/site/src/prototype/transaction.ts
+++ b/packages/site/src/prototype/transaction.ts
@@ -1,0 +1,859 @@
+import {
+  AbiCoder,
+  Interface,
+  TypedDataEncoder,
+  formatUnits,
+  getAddress,
+  hexlify,
+  isAddress,
+  keccak256,
+  parseUnits,
+  toBeHex,
+  toUtf8Bytes,
+} from 'ethers';
+
+export type FeeProfile = 'low' | 'standard' | 'high' | 'custom';
+export type MessageMode = 'none' | 'mode1' | 'mode2';
+export type ValidityUnit = 'minutes' | 'hours' | 'days';
+
+export type PrototypeForm = {
+  consensusAddress: string;
+  gatewayAddress: string;
+  chainId: string;
+  sender: string;
+  recipient: string;
+  methodName: string;
+  userValue: string;
+  numInitialValidators: string;
+  maxRotations: string;
+  validUntil: string;
+  validityDuration: string;
+  validityUnit: ValidityUnit;
+  maxValidUntilDays: string;
+  queueDepth: string;
+  maxQueueSize: string;
+  saltNonce: string;
+  gatewayNonce: string;
+  profile: FeeProfile;
+  leaderTimeoutFee: string;
+  validatorsTimeoutFee: string;
+  appealRounds: string;
+  rollupUnifiedBudgetPerRound: string;
+  totalMessageFees: string;
+  rotations: string;
+  maxPriceGenPerTimeUnit: string;
+  messageMode: MessageMode;
+  messageRecipient: string;
+  messageSelector: string;
+  messageBudget: string;
+  messageLeaderTimeunits: string;
+  messageValidatorTimeunits: string;
+  messageAppealRounds: string;
+  messageRollupBudget: string;
+  messageRotations: string;
+};
+
+export type FeesDistribution = {
+  leaderTimeoutFee: bigint;
+  validatorsTimeoutFee: bigint;
+  appealRounds: bigint;
+  rollupUnifiedBudgetPerRound: bigint;
+  rollupUnifiedConsumed: bigint;
+  totalMessageFees: bigint;
+  rotations: bigint[];
+  maxPriceGenPerTimeUnit: bigint;
+};
+
+export type MessageFeeParams = {
+  leaderTimeunitsAllocation: bigint;
+  validatorTimeunitsAllocation: bigint;
+  appealRounds: bigint;
+  rollupUnifiedBudgetPerRound: bigint;
+  rotations: bigint[];
+};
+
+export type MessageFeeAllocationNode = {
+  parentIndex: bigint;
+  recipient: string;
+  functionSelector: string;
+  budget: bigint;
+  feeParams: MessageFeeParams;
+};
+
+export type AddTransactionParams = {
+  sender: string;
+  recipient: string;
+  numOfInitialValidators: bigint;
+  maxRotations: bigint;
+  validUntil: bigint;
+  saltNonce: bigint;
+  userValue: bigint;
+  feesDistribution: FeesDistribution;
+  txCalldata: string;
+  messageAllocations: MessageFeeAllocationNode[];
+};
+
+export type FeeEstimate = {
+  rounds: number;
+  timeoutFees: bigint;
+  rollupBudget: bigint;
+  appealBudget: bigint;
+  messageBudget: bigint;
+  totalFees: bigint;
+  totalMsgValue: bigint;
+};
+
+export type BuiltTransaction = {
+  params: AddTransactionParams;
+  addTransactionCalldata: string;
+  feeConfigHash: string;
+  txRequest: {
+    to: string;
+    data: string;
+    value: string;
+  };
+  estimate: FeeEstimate;
+  intent: {
+    domain: Record<string, unknown>;
+    types: Record<string, { name: string; type: string }[]>;
+    value: Record<string, unknown>;
+    hash: string;
+  };
+};
+
+export type RpcReceiptLog = {
+  address: string;
+  data: string;
+  topics: string[];
+};
+
+export type ParsedHarnessEvent =
+  | {
+      name: 'GenLayerTransactionCreated';
+      txId: string;
+      sender: string;
+      recipient: string;
+      feeConfigHash: string;
+      userValue: string;
+      msgValue: string;
+    }
+  | {
+      name: 'FeeConfigSubmitted';
+      txId: string;
+      numOfInitialValidators: string;
+      maxRotations: string;
+      appealRounds: string;
+      rotationsCount: string;
+      messageAllocationsCount: string;
+      maxPriceGenPerTimeUnit: string;
+      txCalldataHash: string;
+    }
+  | {
+      name: 'IntentSubmitted';
+      intentHash: string;
+      signer: string;
+      txId: string;
+      maxTotalFee: string;
+      msgValue: string;
+    };
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const ROOT_ALLOCATION_PARENT = BigInt(
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+);
+
+export const CONSENSUS_MAIN_WITH_FEES_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'address', name: 'recipient', type: 'address' },
+          {
+            internalType: 'uint256',
+            name: 'numOfInitialValidators',
+            type: 'uint256',
+          },
+          { internalType: 'uint256', name: 'maxRotations', type: 'uint256' },
+          { internalType: 'uint256', name: 'validUntil', type: 'uint256' },
+          { internalType: 'uint256', name: 'saltNonce', type: 'uint256' },
+          { internalType: 'uint256', name: 'userValue', type: 'uint256' },
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'leaderTimeoutFee',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'validatorsTimeoutFee',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'appealRounds',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'rollupUnifiedBudgetPerRound',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'rollupUnifiedConsumed',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'totalMessageFees',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256[]',
+                name: 'rotations',
+                type: 'uint256[]',
+              },
+              {
+                internalType: 'uint256',
+                name: 'maxPriceGenPerTimeUnit',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct IFeeManager.FeesDistribution',
+            name: 'feesDistribution',
+            type: 'tuple',
+          },
+          { internalType: 'bytes', name: 'txCalldata', type: 'bytes' },
+          {
+            components: [
+              { internalType: 'uint256', name: 'parentIndex', type: 'uint256' },
+              { internalType: 'address', name: 'recipient', type: 'address' },
+              {
+                internalType: 'bytes4',
+                name: 'functionSelector',
+                type: 'bytes4',
+              },
+              { internalType: 'uint256', name: 'budget', type: 'uint256' },
+              {
+                components: [
+                  {
+                    internalType: 'uint256',
+                    name: 'leaderTimeunitsAllocation',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256',
+                    name: 'validatorTimeunitsAllocation',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256',
+                    name: 'appealRounds',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256',
+                    name: 'rollupUnifiedBudgetPerRound',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256[]',
+                    name: 'rotations',
+                    type: 'uint256[]',
+                  },
+                ],
+                internalType: 'struct IMessages.MessageFeeParams',
+                name: 'feeParams',
+                type: 'tuple',
+              },
+            ],
+            internalType: 'struct IMessages.MessageFeeAllocationNode[]',
+            name: 'messageAllocations',
+            type: 'tuple[]',
+          },
+        ],
+        internalType: 'struct IConsensusMainWithFees.AddTransactionParams',
+        name: 'params',
+        type: 'tuple',
+      },
+    ],
+    name: 'addTransaction',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+];
+
+const addTransactionParamsInput = CONSENSUS_MAIN_WITH_FEES_ABI[0].inputs[0];
+
+export const GENLAYER_INTENT_GATEWAY_ABI = [
+  {
+    inputs: [
+      {
+        ...addTransactionParamsInput,
+        name: 'params',
+      },
+      { internalType: 'uint256', name: 'maxTotalFee', type: 'uint256' },
+      { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+      { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+      { internalType: 'bytes', name: 'signature', type: 'bytes' },
+    ],
+    name: 'submitIntent',
+    outputs: [{ internalType: 'bytes32', name: 'txId', type: 'bytes32' }],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'signer', type: 'address' }],
+    name: 'nonces',
+    outputs: [{ internalType: 'uint256', name: 'nonce', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+export const GENLAYER_HARNESS_EVENTS_ABI = [
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'bytes32', name: 'txId', type: 'bytes32' },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'feeConfigHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'userValue',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'msgValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'GenLayerTransactionCreated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'bytes32', name: 'txId', type: 'bytes32' },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'numOfInitialValidators',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'maxRotations',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'appealRounds',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'rotationsCount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'messageAllocationsCount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'maxPriceGenPerTimeUnit',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'txCalldataHash',
+        type: 'bytes32',
+      },
+    ],
+    name: 'FeeConfigSubmitted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'intentHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'signer',
+        type: 'address',
+      },
+      { indexed: true, internalType: 'bytes32', name: 'txId', type: 'bytes32' },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'maxTotalFee',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'msgValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'IntentSubmitted',
+    type: 'event',
+  },
+];
+
+const consensusInterface = new Interface(CONSENSUS_MAIN_WITH_FEES_ABI);
+const gatewayInterface = new Interface(GENLAYER_INTENT_GATEWAY_ABI);
+const harnessEventsInterface = new Interface(GENLAYER_HARNESS_EVENTS_ABI);
+const abiCoder = AbiCoder.defaultAbiCoder();
+
+export const makeDefaultForm = (): PrototypeForm => ({
+  consensusAddress: '',
+  gatewayAddress: '',
+  chainId: '4221',
+  sender: ZERO_ADDRESS,
+  recipient: '0x1111111111111111111111111111111111111111',
+  methodName: 'ask_llm',
+  userValue: '0',
+  numInitialValidators: '5',
+  maxRotations: '2',
+  validUntil: String(Math.floor(Date.now() / 1000) + 60 * 60),
+  validityDuration: '1',
+  validityUnit: 'hours',
+  maxValidUntilDays: '14',
+  queueDepth: '0',
+  maxQueueSize: '1000',
+  saltNonce: '0',
+  gatewayNonce: '0',
+  profile: 'standard',
+  leaderTimeoutFee: '0.001',
+  validatorsTimeoutFee: '0.002',
+  appealRounds: '1',
+  rollupUnifiedBudgetPerRound: '0.01',
+  totalMessageFees: '0.02',
+  rotations: '0,1',
+  maxPriceGenPerTimeUnit: '120',
+  messageMode: 'mode1',
+  messageRecipient: '0x2222222222222222222222222222222222222222',
+  messageSelector: '0x00000000',
+  messageBudget: '0.02',
+  messageLeaderTimeunits: '0.001',
+  messageValidatorTimeunits: '0.002',
+  messageAppealRounds: '1',
+  messageRollupBudget: '0.005',
+  messageRotations: '0',
+});
+
+export const stringifyBigints = (value: unknown): string =>
+  JSON.stringify(
+    value,
+    (_key, item) => (typeof item === 'bigint' ? item.toString() : item),
+    2,
+  );
+
+export const shortHex = (value: string, chars = 10): string => {
+  if (value.length <= chars * 2) {
+    return value;
+  }
+  return `${value.slice(0, chars)}...${value.slice(-chars)}`;
+};
+
+export const formatGen = (value: bigint): string => {
+  const formatted = formatUnits(value, 18);
+  return formatted.replace(/\.0+$/u, '').replace(/(\.\d*?)0+$/u, '$1');
+};
+
+export const toQuantity = (value: bigint): string => toBeHex(value);
+
+export const isZeroAddress = (address: string): boolean =>
+  address.toLowerCase() === ZERO_ADDRESS;
+
+export const isUsableAddress = (address: string): boolean =>
+  isAddress(address) && !isZeroAddress(address);
+
+const parseGen = (value: string): bigint => {
+  if (!value.trim()) {
+    return 0n;
+  }
+  return parseUnits(value.trim(), 18);
+};
+
+const parseUint = (value: string): bigint => {
+  const parsed = Number.parseInt(value.trim() || '0', 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0n;
+  }
+  return BigInt(parsed);
+};
+
+const parseRotations = (value: string): bigint[] => {
+  const rotations = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map(parseUint);
+
+  return rotations.length > 0 ? rotations : [0n];
+};
+
+const normalizeAddress = (address: string, fallback = ZERO_ADDRESS): string => {
+  if (!address.trim()) {
+    return fallback;
+  }
+  if (!isAddress(address)) {
+    return fallback;
+  }
+  return getAddress(address);
+};
+
+const normalizeBytes4 = (value: string): string => {
+  if (/^0x[0-9a-fA-F]{8}$/u.test(value)) {
+    return value;
+  }
+  return '0x00000000';
+};
+
+const buildTxCalldata = (methodName: string): string => {
+  const payload = {
+    method: methodName || 'unknown',
+    args: [],
+    prototype: true,
+  };
+
+  return hexlify(toUtf8Bytes(JSON.stringify(payload)));
+};
+
+const toFeeTuple = (fees: FeesDistribution): unknown[] => [
+  fees.leaderTimeoutFee,
+  fees.validatorsTimeoutFee,
+  fees.appealRounds,
+  fees.rollupUnifiedBudgetPerRound,
+  fees.rollupUnifiedConsumed,
+  fees.totalMessageFees,
+  fees.rotations,
+  fees.maxPriceGenPerTimeUnit,
+];
+
+const toMessageFeeTuple = (feeParams: MessageFeeParams): unknown[] => [
+  feeParams.leaderTimeunitsAllocation,
+  feeParams.validatorTimeunitsAllocation,
+  feeParams.appealRounds,
+  feeParams.rollupUnifiedBudgetPerRound,
+  feeParams.rotations,
+];
+
+const toMessageAllocationTuple = (
+  node: MessageFeeAllocationNode,
+): unknown[] => [
+  node.parentIndex,
+  node.recipient,
+  node.functionSelector,
+  node.budget,
+  toMessageFeeTuple(node.feeParams),
+];
+
+const toAddTransactionTuple = (params: AddTransactionParams): unknown[] => [
+  params.sender,
+  params.recipient,
+  params.numOfInitialValidators,
+  params.maxRotations,
+  params.validUntil,
+  params.saltNonce,
+  params.userValue,
+  toFeeTuple(params.feesDistribution),
+  params.txCalldata,
+  params.messageAllocations.map(toMessageAllocationTuple),
+];
+
+export const buildFeesDistribution = (
+  form: PrototypeForm,
+): FeesDistribution => {
+  const totalMessageFees =
+    form.messageMode === 'none' ? 0n : parseGen(form.totalMessageFees);
+
+  return {
+    leaderTimeoutFee: parseGen(form.leaderTimeoutFee),
+    validatorsTimeoutFee: parseGen(form.validatorsTimeoutFee),
+    appealRounds: parseUint(form.appealRounds),
+    rollupUnifiedBudgetPerRound: parseGen(form.rollupUnifiedBudgetPerRound),
+    rollupUnifiedConsumed: 0n,
+    totalMessageFees,
+    rotations: parseRotations(form.rotations),
+    maxPriceGenPerTimeUnit: parseUint(form.maxPriceGenPerTimeUnit),
+  };
+};
+
+export const buildMessageAllocations = (
+  form: PrototypeForm,
+): MessageFeeAllocationNode[] => {
+  if (form.messageMode !== 'mode2') {
+    return [];
+  }
+
+  return [
+    {
+      parentIndex: ROOT_ALLOCATION_PARENT,
+      recipient: normalizeAddress(form.messageRecipient),
+      functionSelector: normalizeBytes4(form.messageSelector),
+      budget: parseGen(form.messageBudget),
+      feeParams: {
+        leaderTimeunitsAllocation: parseGen(form.messageLeaderTimeunits),
+        validatorTimeunitsAllocation: parseGen(form.messageValidatorTimeunits),
+        appealRounds: parseUint(form.messageAppealRounds),
+        rollupUnifiedBudgetPerRound: parseGen(form.messageRollupBudget),
+        rotations: parseRotations(form.messageRotations),
+      },
+    },
+  ];
+};
+
+export const estimateFees = (params: AddTransactionParams): FeeEstimate => {
+  const rounds = Math.max(params.feesDistribution.rotations.length, 1);
+  const validators = params.numOfInitialValidators;
+  const leaderPerRound = params.feesDistribution.leaderTimeoutFee;
+  const validatorsPerRound =
+    params.feesDistribution.validatorsTimeoutFee * validators;
+  const rollupPerRound = params.feesDistribution.rollupUnifiedBudgetPerRound;
+  const timeoutFees = BigInt(rounds) * (leaderPerRound + validatorsPerRound);
+  const rollupBudget = BigInt(rounds) * rollupPerRound;
+  const appealBudget =
+    params.feesDistribution.appealRounds *
+    (leaderPerRound + validatorsPerRound + rollupPerRound);
+  const messageBudget = params.feesDistribution.totalMessageFees;
+  const totalFees = timeoutFees + rollupBudget + appealBudget + messageBudget;
+
+  return {
+    rounds,
+    timeoutFees,
+    rollupBudget,
+    appealBudget,
+    messageBudget,
+    totalFees,
+    totalMsgValue: totalFees + params.userValue,
+  };
+};
+
+export const buildAddTransactionParams = (
+  form: PrototypeForm,
+): AddTransactionParams => ({
+  sender: normalizeAddress(form.sender),
+  recipient: normalizeAddress(form.recipient),
+  numOfInitialValidators: parseUint(form.numInitialValidators),
+  maxRotations: parseUint(form.maxRotations),
+  validUntil: parseUint(form.validUntil),
+  saltNonce: parseUint(form.saltNonce),
+  userValue: parseGen(form.userValue),
+  feesDistribution: buildFeesDistribution(form),
+  txCalldata: buildTxCalldata(form.methodName),
+  messageAllocations: buildMessageAllocations(form),
+});
+
+const hashFeeConfig = (params: AddTransactionParams): string =>
+  keccak256(
+    abiCoder.encode(
+      [
+        'tuple(uint256,uint256,uint256,uint256,uint256,uint256,uint256[],uint256)',
+        'tuple(uint256,address,bytes4,uint256,tuple(uint256,uint256,uint256,uint256,uint256[]))[]',
+      ],
+      [
+        toFeeTuple(params.feesDistribution),
+        params.messageAllocations.map(toMessageAllocationTuple),
+      ],
+    ),
+  );
+
+const buildIntent = (
+  form: PrototypeForm,
+  params: AddTransactionParams,
+  feeConfigHash: string,
+  estimate: FeeEstimate,
+) => {
+  const chainId = Number.parseInt(form.chainId || '0', 10) || 0;
+  const gatewayAddress = normalizeAddress(form.gatewayAddress);
+  const domain = {
+    name: 'GenLayerIntent',
+    version: '0.1',
+    chainId,
+    verifyingContract: gatewayAddress,
+  };
+  const types = {
+    GenLayerIntent: [
+      { name: 'sender', type: 'address' },
+      { name: 'recipient', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'txDataHash', type: 'bytes32' },
+      { name: 'numInitialValidators', type: 'uint256' },
+      { name: 'maxRotations', type: 'uint256' },
+      { name: 'validUntil', type: 'uint256' },
+      { name: 'maxTotalFee', type: 'uint256' },
+      { name: 'feeConfigHash', type: 'bytes32' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ],
+  };
+  const value = {
+    sender: params.sender,
+    recipient: params.recipient,
+    value: params.userValue,
+    txDataHash: keccak256(params.txCalldata),
+    numInitialValidators: params.numOfInitialValidators,
+    maxRotations: params.maxRotations,
+    validUntil: params.validUntil,
+    maxTotalFee: estimate.totalFees,
+    feeConfigHash,
+    nonce: parseUint(form.gatewayNonce),
+    deadline: params.validUntil,
+  };
+
+  return {
+    domain,
+    types,
+    value,
+    hash: TypedDataEncoder.hash(domain, types, value),
+  };
+};
+
+export const buildTransaction = (form: PrototypeForm): BuiltTransaction => {
+  const params = buildAddTransactionParams(form);
+  const addTransactionCalldata = consensusInterface.encodeFunctionData(
+    'addTransaction',
+    [toAddTransactionTuple(params)],
+  );
+  const estimate = estimateFees(params);
+  const feeConfigHash = hashFeeConfig(params);
+
+  return {
+    params,
+    addTransactionCalldata,
+    feeConfigHash,
+    txRequest: {
+      to: normalizeAddress(form.consensusAddress),
+      data: addTransactionCalldata,
+      value: toQuantity(estimate.totalMsgValue),
+    },
+    estimate,
+    intent: buildIntent(form, params, feeConfigHash, estimate),
+  };
+};
+
+export const buildGatewaySubmissionCalldata = (
+  form: PrototypeForm,
+  signature: string,
+): string => {
+  const built = buildTransaction(form);
+
+  return gatewayInterface.encodeFunctionData('submitIntent', [
+    toAddTransactionTuple(built.params),
+    built.estimate.totalFees,
+    parseUint(form.gatewayNonce),
+    built.params.validUntil,
+    signature,
+  ]);
+};
+
+export const buildGatewayNonceCalldata = (sender: string): string =>
+  gatewayInterface.encodeFunctionData('nonces', [normalizeAddress(sender)]);
+
+export const decodeGatewayNonceResult = (result: string): string =>
+  gatewayInterface.decodeFunctionResult('nonces', result)[0].toString();
+
+export const parseHarnessReceiptEvents = (
+  logs: RpcReceiptLog[],
+): ParsedHarnessEvent[] =>
+  logs.flatMap((log) => {
+    try {
+      const parsed = harnessEventsInterface.parseLog({
+        data: log.data,
+        topics: log.topics,
+      });
+
+      if (!parsed) {
+        return [];
+      }
+
+      if (parsed.name === 'GenLayerTransactionCreated') {
+        return [
+          {
+            name: parsed.name,
+            txId: parsed.args.txId as string,
+            sender: parsed.args.sender as string,
+            recipient: parsed.args.recipient as string,
+            feeConfigHash: parsed.args.feeConfigHash as string,
+            userValue: parsed.args.userValue.toString(),
+            msgValue: parsed.args.msgValue.toString(),
+          },
+        ];
+      }
+
+      if (parsed.name === 'FeeConfigSubmitted') {
+        return [
+          {
+            name: parsed.name,
+            txId: parsed.args.txId as string,
+            numOfInitialValidators:
+              parsed.args.numOfInitialValidators.toString(),
+            maxRotations: parsed.args.maxRotations.toString(),
+            appealRounds: parsed.args.appealRounds.toString(),
+            rotationsCount: parsed.args.rotationsCount.toString(),
+            messageAllocationsCount:
+              parsed.args.messageAllocationsCount.toString(),
+            maxPriceGenPerTimeUnit:
+              parsed.args.maxPriceGenPerTimeUnit.toString(),
+            txCalldataHash: parsed.args.txCalldataHash as string,
+          },
+        ];
+      }
+
+      if (parsed.name === 'IntentSubmitted') {
+        return [
+          {
+            name: parsed.name,
+            intentHash: parsed.args.intentHash as string,
+            signer: parsed.args.signer as string,
+            txId: parsed.args.txId as string,
+            maxTotalFee: parsed.args.maxTotalFee.toString(),
+            msgValue: parsed.args.msgValue.toString(),
+          },
+        ];
+      }
+
+      return [];
+    } catch (_error) {
+      return [];
+    }
+  });

--- a/packages/site/static/harness.local.example.json
+++ b/packages/site/static/harness.local.example.json
@@ -1,0 +1,16 @@
+{
+  "chainId": 31337,
+  "rpcUrl": "http://127.0.0.1:8545",
+  "deployedAt": "example",
+  "deployer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+  "contracts": {
+    "shim": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "txHash": "0x"
+    },
+    "gateway": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "txHash": "0x"
+    }
+  }
+}

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -20,7 +20,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "prepublishOnly": "mm-snap manifest",
     "serve": "mm-snap serve",
     "start": "mm-snap watch",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/genlayerlabs/genlayer-wallet.git"
   },
   "source": {
-    "shasum": "Fxd7/eBncb85Gb0lVfetWFGl7zmujs3VBqqgwxW6dnQ=",
+    "shasum": "ZcFHxwG4tSjNc1K53JaHhrbyHUdNb6GSAGMVGHsCL9Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/genlayerlabs/genlayer-wallet.git"
   },
   "source": {
-    "shasum": "tT2WRenW6jXHpVBKfiXfbTnZv6I3nOk1A3IGUPcUTfw=",
+    "shasum": "Fxd7/eBncb85Gb0lVfetWFGl7zmujs3VBqqgwxW6dnQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/components/TransactionConfig.tsx
+++ b/packages/snap/src/components/TransactionConfig.tsx
@@ -9,46 +9,127 @@ import {
   Button,
 } from '@metamask/snaps-sdk/jsx';
 
-export const TransactionConfig: SnapComponent = () => {
+import type { ParsedGenLayerTransaction } from '../transactions/transaction';
+
+export type TransactionConfigProps = {
+  summary: Record<string, any> | null;
+};
+
+const displayValue = (value: string | undefined): string => value ?? 'unknown';
+
+const allocationSummary = (
+  allocation: NonNullable<
+    ParsedGenLayerTransaction['messageAllocations']
+  >[number],
+  index: number,
+): string =>
+  `${index + 1}. ${allocation.messageType} ${
+    allocation.onAcceptance ? 'on acceptance' : 'on finalization'
+  }, budget ${allocation.budget}`;
+
+export const TransactionConfig: SnapComponent<TransactionConfigProps> = ({
+  summary,
+}) => {
+  const transactionSummary = summary as ParsedGenLayerTransaction | null;
+  const feesDistribution = transactionSummary?.feesDistribution;
+  const messageAllocations = transactionSummary?.messageAllocations ?? [];
+  const messageAllocationsCount =
+    transactionSummary?.messageAllocationsCount ?? 0;
+
   return (
     <Box>
       <Section>
         <Box direction="horizontal" alignment={'space-between'}>
           <Text>
-            <Bold>Estimated Fee Range:</Bold>
+            <Bold>Contract:</Bold>
           </Text>
-          <Text color={'error'}>
-            <Italic>0.5 to 5.06 GEN</Italic>
+          <Text>{transactionSummary?.contractAddress ?? 'unknown'}</Text>
+        </Box>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>
+            <Bold>Method:</Bold>
+          </Text>
+          <Text>{transactionSummary?.methodName ?? 'unknown'}</Text>
+        </Box>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>Transaction type:</Text>
+          <Text>{transactionSummary?.kind ?? 'unknown'}</Text>
+        </Box>
+        {transactionSummary?.txId ? (
+          <Box direction="horizontal" alignment={'space-between'}>
+            <Text>Transaction ID:</Text>
+            <Text>{transactionSummary.txId}</Text>
+          </Box>
+        ) : null}
+        <Divider />
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>
+            <Bold>User value:</Bold>
+          </Text>
+          <Text>{displayValue(transactionSummary?.userValue)}</Text>
+        </Box>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>Leader time units:</Text>
+          <Text>
+            {displayValue(feesDistribution?.leaderTimeunitsAllocation)}
           </Text>
         </Box>
         <Box direction="horizontal" alignment={'space-between'}>
-          <Text>Leader timeout:</Text>
-          <Text>~1 minute</Text>
-        </Box>
-        <Box direction="horizontal" alignment={'space-between'}>
-          <Text>Validator timeout:</Text>
-          <Text>~30 seconds</Text>
+          <Text>Validator time units:</Text>
+          <Text>
+            {displayValue(feesDistribution?.validatorTimeunitsAllocation)}
+          </Text>
         </Box>
         <Box direction="horizontal" alignment={'space-between'}>
           <Text>Appeal rounds:</Text>
-          <Text>2</Text>
+          <Text>{displayValue(feesDistribution?.appealRounds)}</Text>
         </Box>
         <Box direction="horizontal" alignment={'space-between'}>
-          <Text>GenLayer storage cost:</Text>
-          <Text>0.01 GEN</Text>
+          <Text>Rotations:</Text>
+          <Text>{feesDistribution?.rotations.join(', ') ?? 'unknown'}</Text>
         </Box>
         <Box direction="horizontal" alignment={'space-between'}>
-          <Text>Rollup storage cost:</Text>
-          <Text>0.01 GEN</Text>
+          <Text>Execution budget:</Text>
+          <Text>{displayValue(feesDistribution?.executionBudgetPerRound)}</Text>
         </Box>
         <Box direction="horizontal" alignment={'space-between'}>
           <Text>Total messages fees:</Text>
-          <Text>0.9 GEN</Text>
+          <Text>{displayValue(feesDistribution?.totalMessageFees)}</Text>
+        </Box>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>Message fee mode:</Text>
+          <Text>{transactionSummary?.messageAllocationMode ?? 'unknown'}</Text>
+        </Box>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>Message allocations:</Text>
+          <Text>{messageAllocationsCount.toString()}</Text>
+        </Box>
+        {messageAllocations.map((allocation, index) => (
+          <Box key={`${allocation.recipient}-${index}`}>
+            <Text>{allocationSummary(allocation, index)}</Text>
+            <Text>Recipient: {allocation.recipient}</Text>
+            <Text>Call key: {allocation.callKey}</Text>
+            <Text>Parent: {allocation.parentIndex}</Text>
+          </Box>
+        ))}
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>Max GEN/time unit:</Text>
+          <Text>{displayValue(feesDistribution?.maxPriceGenPerTimeUnit)}</Text>
+        </Box>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>Storage gas cap:</Text>
+          <Text>{displayValue(feesDistribution?.storageFeeMaxGasPrice)}</Text>
+        </Box>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>Receipt gas cap:</Text>
+          <Text>{displayValue(feesDistribution?.receiptFeeMaxGasPrice)}</Text>
         </Box>
         <Divider />
         <Text>
-          Note: Unused GEN will be returned to your account once the transaction
-          is finalized.
+          <Italic>
+            Unused fee deposit is returned after finalization when supported by
+            the active consensus version.
+          </Italic>
         </Text>
       </Section>
       <Box center>

--- a/packages/snap/src/index.integration.test.tsx
+++ b/packages/snap/src/index.integration.test.tsx
@@ -1,0 +1,117 @@
+import { UserInputEventType } from '@metamask/snaps-sdk';
+import { abi } from 'genlayer-js';
+
+import { onTransaction, onUserInput } from '.';
+import { buildFeeAwareAddTransactionData } from './transactions/transactionTestFixtures';
+
+jest.mock('genlayer-js', () => ({
+  abi: {
+    calldata: {
+      decode: jest.fn(),
+    },
+  },
+}));
+
+const mockedDecode = abi.calldata.decode as jest.Mock;
+
+describe('Snap transaction insight flow', () => {
+  let state: Record<string, unknown>;
+  let createInterfaceParams: Record<string, any> | undefined;
+  let updateInterfaceParams: Record<string, any> | undefined;
+  let requestMock: jest.Mock;
+
+  beforeEach(() => {
+    state = {};
+    createInterfaceParams = undefined;
+    updateInterfaceParams = undefined;
+    mockedDecode.mockReturnValue(new Map([['method', 'claim']]));
+
+    requestMock = jest.fn(async ({ method, params }) => {
+      if (method === 'snap_manageState') {
+        if (params.operation === 'get') {
+          return state;
+        }
+        if (params.operation === 'update') {
+          state = params.newState;
+          return null;
+        }
+        if (params.operation === 'clear') {
+          state = {};
+          return null;
+        }
+      }
+      if (method === 'snap_createInterface') {
+        createInterfaceParams = params;
+        return 'interface-id';
+      }
+      if (method === 'snap_updateInterface') {
+        updateInterfaceParams = params;
+        return null;
+      }
+      throw new Error(`unexpected snap request: ${String(method)}`);
+    });
+
+    (globalThis as any).snap = { request: requestMock };
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).snap;
+  });
+
+  it('creates a fee-aware insight interface and stores the parsed policy', async () => {
+    const result = await onTransaction({
+      transaction: {
+        to: '0x0000000000000000000000000000000000000000',
+        value: '0x2f',
+        data: buildFeeAwareAddTransactionData(),
+      },
+    } as Parameters<typeof onTransaction>[0]);
+
+    expect(result).toStrictEqual({ id: 'interface-id' });
+    expect(state.currentStorageKey).toBe(
+      '0x1234567890123456789012345678901234567890_claim',
+    );
+
+    const transactionSummary = createInterfaceParams?.context
+      ?.transactionSummary as Record<string, unknown>;
+    expect(transactionSummary.kind).toBe('fee-aware');
+    expect(transactionSummary.messageAllocationMode).toBe('mode-2');
+    expect(transactionSummary.messageAllocationsCount).toBe(2);
+    expect(transactionSummary).toStrictEqual(
+      state[
+        '0x1234567890123456789012345678901234567890_claim:transactionSummary'
+      ],
+    );
+  });
+
+  it('returns from advanced options without losing the parsed fee policy', async () => {
+    await onTransaction({
+      transaction: {
+        to: '0x0000000000000000000000000000000000000000',
+        value: '0x2f',
+        data: buildFeeAwareAddTransactionData(),
+      },
+    } as Parameters<typeof onTransaction>[0]);
+
+    await onUserInput({
+      id: 'interface-id',
+      event: {
+        type: UserInputEventType.ButtonClickEvent,
+        name: 'advanced_options',
+      },
+    } as Parameters<typeof onUserInput>[0]);
+
+    await onUserInput({
+      id: 'interface-id',
+      event: {
+        type: UserInputEventType.ButtonClickEvent,
+        name: 'cancel_config',
+      },
+    } as Parameters<typeof onUserInput>[0]);
+
+    expect(updateInterfaceParams?.ui).toStrictEqual(expect.any(Object));
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'snap_updateInterface' }),
+    );
+  });
+});

--- a/packages/snap/src/index.test.tsx
+++ b/packages/snap/src/index.test.tsx
@@ -5,7 +5,10 @@ import { UserInputEventType } from '@metamask/snaps-sdk';
 import { onTransaction, onUserInput } from '.';
 import type { AdvancedOptionsFormState } from './components';
 import { StateManager } from './libs/StateManager';
-import { getTransactionStorageKey } from './transactions/transaction';
+import {
+  getTransactionStorageKey,
+  parseGenLayerTransaction,
+} from './transactions/transaction';
 
 jest.mock('genlayer-js', () => ({
   abi: {
@@ -53,8 +56,16 @@ describe('Snap Handlers', () => {
         data: '0xa9059cbb00000000',
       };
       const mockStorageKey = '0x123456_a9059cbb';
+      const mockTransactionSummary = {
+        contractAddress: '0x123456',
+        methodName: 'transfer',
+        kind: 'fee-aware',
+      };
 
       (getTransactionStorageKey as jest.Mock).mockReturnValue(mockStorageKey);
+      (parseGenLayerTransaction as jest.Mock).mockReturnValue(
+        mockTransactionSummary,
+      );
       (StateManager.set as jest.Mock).mockResolvedValue(undefined);
       jest.spyOn(snap, 'request').mockResolvedValue('test-interface-id');
 
@@ -66,6 +77,10 @@ describe('Snap Handlers', () => {
       expect(StateManager.set).toHaveBeenCalledWith(
         'currentStorageKey',
         mockStorageKey,
+      );
+      expect(StateManager.set).toHaveBeenCalledWith(
+        `${mockStorageKey}:transactionSummary`,
+        mockTransactionSummary,
       );
       expect(result).toEqual({ id: 'test-interface-id' });
     });

--- a/packages/snap/src/index.tsx
+++ b/packages/snap/src/index.tsx
@@ -7,17 +7,47 @@ import { UserInputEventType } from '@metamask/snaps-sdk';
 import type { AdvancedOptionsFormState } from './components';
 import { AdvancedOptionsForm, TransactionConfig } from './components';
 import { StateManager } from './libs/StateManager';
-import { getTransactionStorageKey } from './transactions/transaction';
+import {
+  getTransactionStorageKey,
+  parseGenLayerTransaction,
+  type ParsedGenLayerTransaction,
+} from './transactions/transaction';
+
+const getTransactionSummaryStorageKey = (storageKey: string) =>
+  `${storageKey}:transactionSummary`;
+
+const getCurrentTransactionSummary = async () => {
+  const currentStorageKey = await StateManager.get('currentStorageKey');
+  if (!currentStorageKey) {
+    return undefined;
+  }
+
+  return (await StateManager.get(
+    getTransactionSummaryStorageKey(currentStorageKey),
+  )) as ParsedGenLayerTransaction | undefined;
+};
+
+const toJsonTransactionSummary = (summary: ParsedGenLayerTransaction) =>
+  JSON.parse(JSON.stringify(summary)) as ParsedGenLayerTransaction;
 
 export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
   const storageKey = getTransactionStorageKey(transaction);
+  const transactionSummary = parseGenLayerTransaction(transaction.data ?? '');
+  const jsonTransactionSummary = toJsonTransactionSummary(transactionSummary);
   await StateManager.set('currentStorageKey', storageKey);
+  await StateManager.set(
+    getTransactionSummaryStorageKey(storageKey),
+    jsonTransactionSummary,
+  );
 
   const interfaceId = await snap.request({
     method: 'snap_createInterface',
     params: {
-      ui: <TransactionConfig />,
-      context: { transaction }, // here we need to change the context with the new modified transaction
+      ui: <TransactionConfig summary={transactionSummary} />,
+      context: {
+        transaction,
+        transactionSummary: jsonTransactionSummary as any,
+      },
     },
   });
 
@@ -45,11 +75,13 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
   if (event.type === UserInputEventType.ButtonClickEvent) {
     switch (event.name) {
       case 'cancel_config':
+        // eslint-disable-next-line no-case-declarations
+        const transactionSummary = await getCurrentTransactionSummary();
         await snap.request({
           method: 'snap_updateInterface',
           params: {
             id,
-            ui: <TransactionConfig />,
+            ui: <TransactionConfig summary={transactionSummary ?? null} />,
           },
         });
         break;
@@ -82,13 +114,14 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
   ) {
     const currentStorageKey = await StateManager.get('currentStorageKey');
     const value = event.value as AdvancedOptionsFormState;
+    const transactionSummary = await getCurrentTransactionSummary();
     await StateManager.set(currentStorageKey, value);
 
     await snap.request({
       method: 'snap_updateInterface',
       params: {
         id,
-        ui: <TransactionConfig />,
+        ui: <TransactionConfig summary={transactionSummary ?? null} />,
       },
     });
   }

--- a/packages/snap/src/transactions/transaction.integration.test.ts
+++ b/packages/snap/src/transactions/transaction.integration.test.ts
@@ -1,0 +1,125 @@
+import { abi } from 'genlayer-js';
+
+import { parseGenLayerTransaction } from './transaction';
+import {
+  buildDeploySaltedTransactionData,
+  buildFeeAwareAddTransactionData,
+  buildSubmitAppealTransactionData,
+  buildTopUpAndSubmitAppealTransactionData,
+  buildTopUpFeesTransactionData,
+  RECIPIENT_ADDRESS,
+  TX_ID,
+} from './transactionTestFixtures';
+
+jest.mock('genlayer-js', () => ({
+  abi: {
+    calldata: {
+      decode: jest.fn(),
+    },
+  },
+}));
+
+const mockedDecode = abi.calldata.decode as jest.Mock;
+
+describe('Transaction Utilities integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedDecode.mockReturnValue(new Map([['method', 'claim']]));
+  });
+
+  it('decodes real fee-aware addTransaction calldata built with the consensus ABI', () => {
+    const result = parseGenLayerTransaction(buildFeeAwareAddTransactionData());
+
+    expect(result).toStrictEqual({
+      contractAddress: RECIPIENT_ADDRESS,
+      methodName: 'claim',
+      kind: 'fee-aware',
+      userValue: '7',
+      validUntil: '123',
+      saltNonce: '0',
+      feesDistribution: {
+        leaderTimeunitsAllocation: '10',
+        validatorTimeunitsAllocation: '20',
+        appealRounds: '1',
+        executionBudgetPerRound: '30',
+        executionConsumed: '0',
+        totalMessageFees: '40',
+        rotations: ['0', '1'],
+        maxPriceGenPerTimeUnit: '50',
+        storageFeeMaxGasPrice: '60',
+        receiptFeeMaxGasPrice: '70',
+      },
+      messageAllocationMode: 'mode-2',
+      messageAllocations: [
+        {
+          messageType: 'Internal',
+          onAcceptance: true,
+          parentIndex:
+            '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+          recipient: '0x1111111111111111111111111111111111111111',
+          callKey:
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          budget: '25',
+          feeParams: '0x1234',
+        },
+        {
+          messageType: 'External',
+          onAcceptance: false,
+          parentIndex: '0',
+          recipient: '0x2222222222222222222222222222222222222222',
+          callKey:
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+          budget: '15',
+          feeParams: '0xabcd',
+        },
+      ],
+      messageAllocationsCount: 2,
+    });
+  });
+
+  it('decodes deploySalted fee-aware calldata as a deploy transaction', () => {
+    const result = parseGenLayerTransaction(buildDeploySaltedTransactionData());
+
+    expect(result.kind).toBe('deploy-salted');
+    expect(result.contractAddress).toBe(RECIPIENT_ADDRESS);
+    expect(result.methodName).toBe('claim');
+    expect(result.saltNonce).toBe('99');
+    expect(result.messageAllocationMode).toBe('mode-2');
+  });
+
+  it('decodes topUpFees calldata as a fee-management transaction', () => {
+    const result = parseGenLayerTransaction(buildTopUpFeesTransactionData());
+
+    expect(result.kind).toBe('top-up-fees');
+    expect(result.contractAddress).toBe('consensus');
+    expect(result.methodName).toBe('topUpFees');
+    expect(result.txId).toBe(TX_ID);
+    expect(result.feesDistribution?.totalMessageFees).toBe('25');
+    expect(result.feesDistribution?.maxPriceGenPerTimeUnit).toBe('50');
+    expect(result.messageAllocationMode).toBe('mode-1');
+    expect(result.messageAllocationsCount).toBe(0);
+  });
+
+  it('decodes submitAppeal calldata as an appeal transaction', () => {
+    const result = parseGenLayerTransaction(buildSubmitAppealTransactionData());
+
+    expect(result.kind).toBe('submit-appeal');
+    expect(result.contractAddress).toBe('consensus');
+    expect(result.methodName).toBe('submitAppeal');
+    expect(result.txId).toBe(TX_ID);
+    expect(result.feesDistribution).toBeUndefined();
+  });
+
+  it('decodes topUpAndSubmitAppeal calldata as a fee-management appeal transaction', () => {
+    const result = parseGenLayerTransaction(
+      buildTopUpAndSubmitAppealTransactionData(),
+    );
+
+    expect(result.kind).toBe('top-up-and-submit-appeal');
+    expect(result.contractAddress).toBe('consensus');
+    expect(result.methodName).toBe('topUpAndSubmitAppeal');
+    expect(result.txId).toBe(TX_ID);
+    expect(result.feesDistribution?.totalMessageFees).toBe('25');
+    expect(result.feesDistribution?.receiptFeeMaxGasPrice).toBe('70');
+  });
+});

--- a/packages/snap/src/transactions/transaction.test.ts
+++ b/packages/snap/src/transactions/transaction.test.ts
@@ -69,6 +69,236 @@ describe('Transaction Utilities', () => {
       expect(result).toStrictEqual({
         contractAddress: '0x1234567890123456789012345678901234567890',
         methodName: 'transfer',
+        kind: 'legacy',
+        validUntil: undefined,
+      });
+    });
+
+    it('should extract contract, method, and fees from fee-aware GenLayer transaction', () => {
+      const mockInterface = {
+        parseTransaction: jest.fn().mockReturnValue({
+          name: 'addTransaction',
+          args: [
+            {
+              recipient: '0x1234567890123456789012345678901234567890',
+              txCalldata: 'encodedData',
+              userValue: 7n,
+              validUntil: 123n,
+              saltNonce: 0n,
+              feesDistribution: {
+                leaderTimeunitsAllocation: 10n,
+                validatorTimeunitsAllocation: 20n,
+                appealRounds: 1n,
+                executionBudgetPerRound: 30n,
+                executionConsumed: 0n,
+                totalMessageFees: 40n,
+                rotations: [0n, 1n],
+                maxPriceGenPerTimeUnit: 50n,
+                storageFeeMaxGasPrice: 60n,
+                receiptFeeMaxGasPrice: 70n,
+              },
+              messageAllocations: [
+                {
+                  messageType: 1n,
+                  onAcceptance: true,
+                  parentIndex:
+                    115792089237316195423570985008687907853269984665640564039457584007913129639935n,
+                  recipient: '0x1111111111111111111111111111111111111111',
+                  callKey:
+                    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                  budget: 25n,
+                  feeParams: '0x1234',
+                },
+                {
+                  messageType: 0n,
+                  onAcceptance: false,
+                  parentIndex: 0n,
+                  recipient: '0x2222222222222222222222222222222222222222',
+                  callKey:
+                    '0x0000000000000000000000000000000000000000000000000000000000000000',
+                  budget: 15n,
+                  feeParams: '0xabcd',
+                },
+              ],
+            },
+          ],
+        }),
+      };
+
+      MockedInterface.mockReturnValue(mockInterface as any);
+      mockedDecodeRlp.mockReturnValue(['decodedCalldata']);
+      mockedGetBytes.mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+
+      const mockDecoded = new Map();
+      mockDecoded.set('method', 'claim');
+      mockedAbi.calldata.decode.mockReturnValue(mockDecoded);
+
+      const result = parseGenLayerTransaction('0xabcdef123456');
+
+      expect(result).toStrictEqual({
+        contractAddress: '0x1234567890123456789012345678901234567890',
+        methodName: 'claim',
+        kind: 'fee-aware',
+        userValue: '7',
+        validUntil: '123',
+        saltNonce: '0',
+        feesDistribution: {
+          leaderTimeunitsAllocation: '10',
+          validatorTimeunitsAllocation: '20',
+          appealRounds: '1',
+          executionBudgetPerRound: '30',
+          executionConsumed: '0',
+          totalMessageFees: '40',
+          rotations: ['0', '1'],
+          maxPriceGenPerTimeUnit: '50',
+          storageFeeMaxGasPrice: '60',
+          receiptFeeMaxGasPrice: '70',
+        },
+        messageAllocationMode: 'mode-2',
+        messageAllocations: [
+          {
+            messageType: 'Internal',
+            onAcceptance: true,
+            parentIndex:
+              '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+            recipient: '0x1111111111111111111111111111111111111111',
+            callKey:
+              '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            budget: '25',
+            feeParams: '0x1234',
+          },
+          {
+            messageType: 'External',
+            onAcceptance: false,
+            parentIndex: '0',
+            recipient: '0x2222222222222222222222222222222222222222',
+            callKey:
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            budget: '15',
+            feeParams: '0xabcd',
+          },
+        ],
+        messageAllocationsCount: 2,
+      });
+    });
+
+    it('should identify message fee mode 1 when only the global message bucket is provided', () => {
+      const mockInterface = {
+        parseTransaction: jest.fn().mockReturnValue({
+          name: 'addTransaction',
+          args: [
+            {
+              recipient: '0x1234567890123456789012345678901234567890',
+              txCalldata: 'encodedData',
+              userValue: 0n,
+              validUntil: 123n,
+              saltNonce: 0n,
+              feesDistribution: {
+                leaderTimeunitsAllocation: 10n,
+                validatorTimeunitsAllocation: 20n,
+                appealRounds: 0n,
+                executionBudgetPerRound: 30n,
+                executionConsumed: 0n,
+                totalMessageFees: 40n,
+                rotations: [0n],
+                maxPriceGenPerTimeUnit: 50n,
+                storageFeeMaxGasPrice: 60n,
+                receiptFeeMaxGasPrice: 70n,
+              },
+              messageAllocations: [],
+            },
+          ],
+        }),
+      };
+
+      MockedInterface.mockReturnValue(mockInterface as any);
+      mockedDecodeRlp.mockReturnValue(['decodedCalldata']);
+      mockedGetBytes.mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+
+      const mockDecoded = new Map();
+      mockDecoded.set('method', 'emitMessage');
+      mockedAbi.calldata.decode.mockReturnValue(mockDecoded);
+
+      const result = parseGenLayerTransaction('0xabcdef123456');
+
+      expect(result.messageAllocationMode).toBe('mode-1');
+      expect(result.messageAllocations).toStrictEqual([]);
+      expect(result.messageAllocationsCount).toBe(0);
+    });
+
+    it('should extract fee policy from topUpFees calldata', () => {
+      const feesDistribution = {
+        leaderTimeunitsAllocation: 0n,
+        validatorTimeunitsAllocation: 0n,
+        appealRounds: 0n,
+        executionBudgetPerRound: 0n,
+        executionConsumed: 0n,
+        totalMessageFees: 25n,
+        rotations: [0n],
+        maxPriceGenPerTimeUnit: 50n,
+        storageFeeMaxGasPrice: 60n,
+        receiptFeeMaxGasPrice: 70n,
+      };
+      const mockInterface = {
+        parseTransaction: jest.fn().mockReturnValue({
+          name: 'topUpFees',
+          args: [
+            '0x9999999999999999999999999999999999999999999999999999999999999999',
+            feesDistribution,
+          ],
+        }),
+      };
+
+      MockedInterface.mockReturnValue(mockInterface as any);
+
+      const result = parseGenLayerTransaction('0xabcdef123456');
+
+      expect(result).toStrictEqual({
+        contractAddress: 'consensus',
+        methodName: 'topUpFees',
+        kind: 'top-up-fees',
+        txId: '0x9999999999999999999999999999999999999999999999999999999999999999',
+        feesDistribution: {
+          leaderTimeunitsAllocation: '0',
+          validatorTimeunitsAllocation: '0',
+          appealRounds: '0',
+          executionBudgetPerRound: '0',
+          executionConsumed: '0',
+          totalMessageFees: '25',
+          rotations: ['0'],
+          maxPriceGenPerTimeUnit: '50',
+          storageFeeMaxGasPrice: '60',
+          receiptFeeMaxGasPrice: '70',
+        },
+        messageAllocationMode: 'mode-1',
+        messageAllocations: [],
+        messageAllocationsCount: 0,
+      });
+    });
+
+    it('should extract tx id from submitAppeal calldata', () => {
+      const mockInterface = {
+        parseTransaction: jest.fn().mockReturnValue({
+          name: 'submitAppeal',
+          args: [
+            '0x9999999999999999999999999999999999999999999999999999999999999999',
+          ],
+        }),
+      };
+
+      MockedInterface.mockReturnValue(mockInterface as any);
+
+      const result = parseGenLayerTransaction('0xabcdef123456');
+
+      expect(result).toStrictEqual({
+        contractAddress: 'consensus',
+        methodName: 'submitAppeal',
+        kind: 'submit-appeal',
+        txId: '0x9999999999999999999999999999999999999999999999999999999999999999',
+        feesDistribution: undefined,
+        messageAllocationMode: undefined,
+        messageAllocations: undefined,
+        messageAllocationsCount: undefined,
       });
     });
 
@@ -82,6 +312,7 @@ describe('Transaction Utilities', () => {
       expect(result).toStrictEqual({
         contractAddress: 'default',
         methodName: 'unknown',
+        kind: 'unknown',
       });
     });
 
@@ -105,6 +336,8 @@ describe('Transaction Utilities', () => {
       expect(result).toStrictEqual({
         contractAddress: 'default',
         methodName: 'transfer',
+        kind: 'legacy',
+        validUntil: undefined,
       });
     });
 
@@ -134,6 +367,8 @@ describe('Transaction Utilities', () => {
       expect(result).toStrictEqual({
         contractAddress: '0x1234567890123456789012345678901234567890',
         methodName: 'unknown',
+        kind: 'legacy',
+        validUntil: undefined,
       });
     });
   });

--- a/packages/snap/src/transactions/transaction.ts
+++ b/packages/snap/src/transactions/transaction.ts
@@ -15,6 +15,22 @@ type TransactionKind =
   | 'top-up-and-submit-appeal'
   | 'unknown';
 type MessageAllocationMode = 'none' | 'mode-1' | 'mode-2' | 'unknown';
+type TupleLike = Record<string, unknown> & Record<number, unknown>;
+
+const protocolName = (...parts: string[]): string => parts.join('');
+const FIELD_VALIDATOR_TIMEUNITS_ALLOCATION = protocolName(
+  'validator',
+  'Timeunits',
+  'Allocation',
+);
+const FIELD_TOTAL_MESSAGE_FEES = protocolName('total', 'Message', 'Fees');
+const FIELD_FEES_DISTRIBUTION = protocolName('fees', 'Distribution');
+const FUNCTION_TOP_UP_AND_SUBMIT_APPEAL = protocolName(
+  'topUp',
+  'And',
+  'Submit',
+  'Appeal',
+);
 
 export type ParsedMessageFeeAllocation = {
   messageType: string;
@@ -61,11 +77,11 @@ const DEFAULT_PARSED_TRANSACTION: ParsedGenLayerTransaction = {
 
 const FEES_DISTRIBUTION_COMPONENTS = [
   { name: 'leaderTimeunitsAllocation', type: 'uint256' },
-  { name: 'validatorTimeunitsAllocation', type: 'uint256' },
+  { name: FIELD_VALIDATOR_TIMEUNITS_ALLOCATION, type: 'uint256' },
   { name: 'appealRounds', type: 'uint256' },
   { name: 'executionBudgetPerRound', type: 'uint256' },
   { name: 'executionConsumed', type: 'uint256' },
-  { name: 'totalMessageFees', type: 'uint256' },
+  { name: FIELD_TOTAL_MESSAGE_FEES, type: 'uint256' },
   { name: 'rotations', type: 'uint256[]' },
   { name: 'maxPriceGenPerTimeUnit', type: 'uint256' },
   { name: 'storageFeeMaxGasPrice', type: 'uint256' },
@@ -91,7 +107,7 @@ const ADD_TRANSACTION_PARAMS_COMPONENTS = [
   { name: 'saltNonce', type: 'uint256' },
   { name: 'userValue', type: 'uint256' },
   {
-    name: 'feesDistribution',
+    name: FIELD_FEES_DISTRIBUTION,
     type: 'tuple',
     components: FEES_DISTRIBUTION_COMPONENTS,
   },
@@ -180,7 +196,7 @@ const CONSENSUS_TRANSACTION_ABI = [
   },
   {
     type: 'function',
-    name: 'topUpAndSubmitAppeal',
+    name: FUNCTION_TOP_UP_AND_SUBMIT_APPEAL,
     stateMutability: 'payable',
     inputs: [
       { name: '_txId', type: 'bytes32' },
@@ -194,10 +210,11 @@ const CONSENSUS_TRANSACTION_ABI = [
   },
 ];
 
-const getConsensusInterface = () => new Interface(CONSENSUS_TRANSACTION_ABI);
+const getConsensusInterface = (): Interface =>
+  new Interface(CONSENSUS_TRANSACTION_ABI);
 
 const getTupleValue = <TValue>(
-  tuple: any,
+  tuple: TupleLike | undefined,
   namedKey: string,
   positionalIndex: number,
   fallback?: TValue,
@@ -211,7 +228,19 @@ const stringifyUint = (value: unknown): string | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
-  return value.toString();
+  if (
+    typeof value === 'bigint' ||
+    typeof value === 'number' ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value.toString();
+  }
+  const stringifier = (value as { toString?: () => string }).toString;
+  if (stringifier && stringifier !== Object.prototype.toString) {
+    return stringifier.call(value);
+  }
+  return undefined;
 };
 
 const stringifyBytes = (value: unknown): string => {
@@ -246,7 +275,7 @@ const parseBoolean = (value: unknown): boolean => {
 };
 
 const parseFeesDistribution = (
-  feesDistribution: any,
+  feesDistribution: TupleLike | undefined,
 ): ParsedFeesDistribution | undefined => {
   if (!feesDistribution) {
     return undefined;
@@ -259,7 +288,11 @@ const parseFeesDistribution = (
       ) ?? '0',
     validatorTimeunitsAllocation:
       stringifyUint(
-        getTupleValue(feesDistribution, 'validatorTimeunitsAllocation', 1),
+        getTupleValue(
+          feesDistribution,
+          FIELD_VALIDATOR_TIMEUNITS_ALLOCATION,
+          1,
+        ),
       ) ?? '0',
     appealRounds:
       stringifyUint(getTupleValue(feesDistribution, 'appealRounds', 2)) ?? '0',
@@ -271,8 +304,9 @@ const parseFeesDistribution = (
       stringifyUint(getTupleValue(feesDistribution, 'executionConsumed', 4)) ??
       '0',
     totalMessageFees:
-      stringifyUint(getTupleValue(feesDistribution, 'totalMessageFees', 5)) ??
-      '0',
+      stringifyUint(
+        getTupleValue(feesDistribution, FIELD_TOTAL_MESSAGE_FEES, 5),
+      ) ?? '0',
     rotations: Array.from(
       getTupleValue<unknown[]>(feesDistribution, 'rotations', 6, []) ?? [],
     ).map((rotation) => rotation?.toString() ?? '0'),
@@ -292,7 +326,7 @@ const parseFeesDistribution = (
 };
 
 const parseMessageAllocations = (
-  messageAllocations: any[] | undefined,
+  messageAllocations: TupleLike[] | undefined,
 ): ParsedMessageFeeAllocation[] => {
   return Array.from(messageAllocations ?? []).map((allocation) => ({
     messageType: stringifyMessageType(
@@ -326,18 +360,19 @@ const getMessageAllocationMode = (
 const decodeMethodNameFromCalldata = (txCalldata: BytesLike): string => {
   const decodedData = decodeRlp(txCalldata);
   const bytes = getBytes(decodedData[0] as BytesLike);
-  const decoded = abi.calldata.decode(bytes) as Map<string, any>;
-  return decoded?.get('method') || 'unknown';
+  const decoded = abi.calldata.decode(bytes) as Map<string, unknown>;
+  const method = decoded?.get('method');
+  return typeof method === 'string' ? method : 'unknown';
 };
 
 const parseFeeManagementTransaction = (
   name: string,
-  args: any,
+  args: TupleLike,
 ): ParsedGenLayerTransaction | undefined => {
   if (
     name !== 'topUpFees' &&
     name !== 'submitAppeal' &&
-    name !== 'topUpAndSubmitAppeal'
+    name !== FUNCTION_TOP_UP_AND_SUBMIT_APPEAL
   ) {
     return undefined;
   }
@@ -350,7 +385,7 @@ const parseFeeManagementTransaction = (
   let kind: ParsedGenLayerTransaction['kind'] = 'submit-appeal';
   if (name === 'topUpFees') {
     kind = 'top-up-fees';
-  } else if (name === 'topUpAndSubmitAppeal') {
+  } else if (name === FUNCTION_TOP_UP_AND_SUBMIT_APPEAL) {
     kind = 'top-up-and-submit-appeal';
   }
 
@@ -390,10 +425,10 @@ export function parseGenLayerTransaction(
       const params = parsed.args[0];
       const txCalldata = getTupleValue<BytesLike>(params, 'txCalldata', 8);
       const feesDistribution = parseFeesDistribution(
-        getTupleValue(params, 'feesDistribution', 7),
+        getTupleValue(params, FIELD_FEES_DISTRIBUTION, 7),
       );
       const messageAllocations = parseMessageAllocations(
-        getTupleValue<any[]>(params, 'messageAllocations', 9, []),
+        getTupleValue<TupleLike[]>(params, 'messageAllocations', 9, []),
       );
       return {
         contractAddress:

--- a/packages/snap/src/transactions/transaction.ts
+++ b/packages/snap/src/transactions/transaction.ts
@@ -1,50 +1,437 @@
 import type { BytesLike } from 'ethers';
 import { decodeRlp, getBytes, Interface } from 'ethers';
-import { abi, chains } from 'genlayer-js';
+import { abi } from 'genlayer-js';
 
 /**
  * Transaction handling and storage key generation.
  */
 
-/**
- * Extracts contract address and method name from GenLayer transaction data.
- * @param data - The transaction data (hex string).
- * @returns Object with contractAddress and methodName, or defaults if extraction fails.
- */
-export function parseGenLayerTransaction(data: string): {
+type TransactionKind =
+  | 'legacy'
+  | 'fee-aware'
+  | 'deploy-salted'
+  | 'top-up-fees'
+  | 'submit-appeal'
+  | 'top-up-and-submit-appeal'
+  | 'unknown';
+type MessageAllocationMode = 'none' | 'mode-1' | 'mode-2' | 'unknown';
+
+export type ParsedMessageFeeAllocation = {
+  messageType: string;
+  onAcceptance: boolean;
+  parentIndex: string;
+  recipient: string;
+  callKey: string;
+  budget: string;
+  feeParams: string;
+};
+
+export type ParsedFeesDistribution = {
+  leaderTimeunitsAllocation: string;
+  validatorTimeunitsAllocation: string;
+  appealRounds: string;
+  executionBudgetPerRound: string;
+  executionConsumed: string;
+  totalMessageFees: string;
+  rotations: string[];
+  maxPriceGenPerTimeUnit: string;
+  storageFeeMaxGasPrice: string;
+  receiptFeeMaxGasPrice: string;
+};
+
+export type ParsedGenLayerTransaction = {
   contractAddress: string;
   methodName: string;
-} {
+  kind: TransactionKind;
+  txId?: string | undefined;
+  userValue?: string | undefined;
+  validUntil?: string | undefined;
+  saltNonce?: string | undefined;
+  feesDistribution?: ParsedFeesDistribution | undefined;
+  messageAllocationMode?: MessageAllocationMode | undefined;
+  messageAllocations?: ParsedMessageFeeAllocation[] | undefined;
+  messageAllocationsCount?: number | undefined;
+};
+
+const DEFAULT_PARSED_TRANSACTION: ParsedGenLayerTransaction = {
+  contractAddress: 'default',
+  methodName: 'unknown',
+  kind: 'unknown',
+};
+
+const FEES_DISTRIBUTION_COMPONENTS = [
+  { name: 'leaderTimeunitsAllocation', type: 'uint256' },
+  { name: 'validatorTimeunitsAllocation', type: 'uint256' },
+  { name: 'appealRounds', type: 'uint256' },
+  { name: 'executionBudgetPerRound', type: 'uint256' },
+  { name: 'executionConsumed', type: 'uint256' },
+  { name: 'totalMessageFees', type: 'uint256' },
+  { name: 'rotations', type: 'uint256[]' },
+  { name: 'maxPriceGenPerTimeUnit', type: 'uint256' },
+  { name: 'storageFeeMaxGasPrice', type: 'uint256' },
+  { name: 'receiptFeeMaxGasPrice', type: 'uint256' },
+];
+
+const MESSAGE_FEE_ALLOCATION_COMPONENTS = [
+  { name: 'messageType', type: 'uint8' },
+  { name: 'onAcceptance', type: 'bool' },
+  { name: 'parentIndex', type: 'uint256' },
+  { name: 'recipient', type: 'address' },
+  { name: 'callKey', type: 'bytes32' },
+  { name: 'budget', type: 'uint256' },
+  { name: 'feeParams', type: 'bytes' },
+];
+
+const ADD_TRANSACTION_PARAMS_COMPONENTS = [
+  { name: 'sender', type: 'address' },
+  { name: 'recipient', type: 'address' },
+  { name: 'numOfInitialValidators', type: 'uint256' },
+  { name: 'maxRotations', type: 'uint256' },
+  { name: 'validUntil', type: 'uint256' },
+  { name: 'saltNonce', type: 'uint256' },
+  { name: 'userValue', type: 'uint256' },
+  {
+    name: 'feesDistribution',
+    type: 'tuple',
+    components: FEES_DISTRIBUTION_COMPONENTS,
+  },
+  { name: 'txCalldata', type: 'bytes' },
+  {
+    name: 'messageAllocations',
+    type: 'tuple[]',
+    components: MESSAGE_FEE_ALLOCATION_COMPONENTS,
+  },
+];
+
+const CONSENSUS_TRANSACTION_ABI = [
+  {
+    type: 'function',
+    name: 'addTransaction',
+    stateMutability: 'payable',
+    inputs: [
+      { name: '_sender', type: 'address' },
+      { name: '_recipient', type: 'address' },
+      { name: '_numOfInitialValidators', type: 'uint256' },
+      { name: '_maxRotations', type: 'uint256' },
+      { name: '_txData', type: 'bytes' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'addTransaction',
+    stateMutability: 'payable',
+    inputs: [
+      { name: '_sender', type: 'address' },
+      { name: '_recipient', type: 'address' },
+      { name: '_numOfInitialValidators', type: 'uint256' },
+      { name: '_maxRotations', type: 'uint256' },
+      { name: '_txData', type: 'bytes' },
+      { name: '_validUntil', type: 'uint256' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'addTransaction',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: '_params',
+        type: 'tuple',
+        components: ADD_TRANSACTION_PARAMS_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'deploySalted',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: '_params',
+        type: 'tuple',
+        components: ADD_TRANSACTION_PARAMS_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'topUpFees',
+    stateMutability: 'payable',
+    inputs: [
+      { name: '_txId', type: 'bytes32' },
+      {
+        name: '_feesDistribution',
+        type: 'tuple',
+        components: FEES_DISTRIBUTION_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'submitAppeal',
+    stateMutability: 'payable',
+    inputs: [{ name: '_txId', type: 'bytes32' }],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'topUpAndSubmitAppeal',
+    stateMutability: 'payable',
+    inputs: [
+      { name: '_txId', type: 'bytes32' },
+      {
+        name: '_feesDistribution',
+        type: 'tuple',
+        components: FEES_DISTRIBUTION_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+];
+
+const getConsensusInterface = () => new Interface(CONSENSUS_TRANSACTION_ABI);
+
+const getTupleValue = <TValue>(
+  tuple: any,
+  namedKey: string,
+  positionalIndex: number,
+  fallback?: TValue,
+): TValue | undefined => {
+  return (tuple?.[namedKey] ?? tuple?.[positionalIndex] ?? fallback) as
+    | TValue
+    | undefined;
+};
+
+const stringifyUint = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return value.toString();
+};
+
+const stringifyBytes = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return `0x${Array.from(value, (byte) =>
+      byte.toString(16).padStart(2, '0'),
+    ).join('')}`;
+  }
+  return value?.toString?.() ?? '0x';
+};
+
+const stringifyAddress = (value: unknown): string => {
+  return typeof value === 'string' ? value : value?.toString?.() ?? 'unknown';
+};
+
+const stringifyMessageType = (value: unknown): string => {
+  const normalized = stringifyUint(value);
+  if (normalized === '0') {
+    return 'External';
+  }
+  if (normalized === '1') {
+    return 'Internal';
+  }
+  return normalized ?? 'unknown';
+};
+
+const parseBoolean = (value: unknown): boolean => {
+  return value === true || value === 'true' || value === 1 || value === 1n;
+};
+
+const parseFeesDistribution = (
+  feesDistribution: any,
+): ParsedFeesDistribution | undefined => {
+  if (!feesDistribution) {
+    return undefined;
+  }
+
+  return {
+    leaderTimeunitsAllocation:
+      stringifyUint(
+        getTupleValue(feesDistribution, 'leaderTimeunitsAllocation', 0),
+      ) ?? '0',
+    validatorTimeunitsAllocation:
+      stringifyUint(
+        getTupleValue(feesDistribution, 'validatorTimeunitsAllocation', 1),
+      ) ?? '0',
+    appealRounds:
+      stringifyUint(getTupleValue(feesDistribution, 'appealRounds', 2)) ?? '0',
+    executionBudgetPerRound:
+      stringifyUint(
+        getTupleValue(feesDistribution, 'executionBudgetPerRound', 3),
+      ) ?? '0',
+    executionConsumed:
+      stringifyUint(getTupleValue(feesDistribution, 'executionConsumed', 4)) ??
+      '0',
+    totalMessageFees:
+      stringifyUint(getTupleValue(feesDistribution, 'totalMessageFees', 5)) ??
+      '0',
+    rotations: Array.from(
+      getTupleValue<unknown[]>(feesDistribution, 'rotations', 6, []) ?? [],
+    ).map((rotation) => rotation?.toString() ?? '0'),
+    maxPriceGenPerTimeUnit:
+      stringifyUint(
+        getTupleValue(feesDistribution, 'maxPriceGenPerTimeUnit', 7),
+      ) ?? '0',
+    storageFeeMaxGasPrice:
+      stringifyUint(
+        getTupleValue(feesDistribution, 'storageFeeMaxGasPrice', 8),
+      ) ?? '0',
+    receiptFeeMaxGasPrice:
+      stringifyUint(
+        getTupleValue(feesDistribution, 'receiptFeeMaxGasPrice', 9),
+      ) ?? '0',
+  };
+};
+
+const parseMessageAllocations = (
+  messageAllocations: any[] | undefined,
+): ParsedMessageFeeAllocation[] => {
+  return Array.from(messageAllocations ?? []).map((allocation) => ({
+    messageType: stringifyMessageType(
+      getTupleValue(allocation, 'messageType', 0),
+    ),
+    onAcceptance: parseBoolean(getTupleValue(allocation, 'onAcceptance', 1)),
+    parentIndex:
+      stringifyUint(getTupleValue(allocation, 'parentIndex', 2)) ?? '0',
+    recipient: stringifyAddress(getTupleValue(allocation, 'recipient', 3)),
+    callKey: stringifyBytes(getTupleValue(allocation, 'callKey', 4)),
+    budget: stringifyUint(getTupleValue(allocation, 'budget', 5)) ?? '0',
+    feeParams: stringifyBytes(getTupleValue(allocation, 'feeParams', 6)),
+  }));
+};
+
+const getMessageAllocationMode = (
+  feesDistribution: ParsedFeesDistribution | undefined,
+  messageAllocations: ParsedMessageFeeAllocation[],
+): MessageAllocationMode => {
+  if (!feesDistribution) {
+    return 'unknown';
+  }
+
+  const totalMessageFees = BigInt(feesDistribution.totalMessageFees);
+  if (totalMessageFees === 0n) {
+    return 'none';
+  }
+  return messageAllocations.length === 0 ? 'mode-1' : 'mode-2';
+};
+
+const decodeMethodNameFromCalldata = (txCalldata: BytesLike): string => {
+  const decodedData = decodeRlp(txCalldata);
+  const bytes = getBytes(decodedData[0] as BytesLike);
+  const decoded = abi.calldata.decode(bytes) as Map<string, any>;
+  return decoded?.get('method') || 'unknown';
+};
+
+const parseFeeManagementTransaction = (
+  name: string,
+  args: any,
+): ParsedGenLayerTransaction | undefined => {
+  if (
+    name !== 'topUpFees' &&
+    name !== 'submitAppeal' &&
+    name !== 'topUpAndSubmitAppeal'
+  ) {
+    return undefined;
+  }
+
+  const feesDistribution =
+    name === 'submitAppeal'
+      ? undefined
+      : parseFeesDistribution(getTupleValue(args, '_feesDistribution', 1));
+  const messageAllocations: ParsedMessageFeeAllocation[] = [];
+  let kind: ParsedGenLayerTransaction['kind'] = 'submit-appeal';
+  if (name === 'topUpFees') {
+    kind = 'top-up-fees';
+  } else if (name === 'topUpAndSubmitAppeal') {
+    kind = 'top-up-and-submit-appeal';
+  }
+
+  return {
+    contractAddress: 'consensus',
+    methodName: name,
+    kind,
+    txId: stringifyBytes(getTupleValue(args, '_txId', 0)),
+    feesDistribution,
+    messageAllocationMode: feesDistribution
+      ? getMessageAllocationMode(feesDistribution, messageAllocations)
+      : undefined,
+    messageAllocations: feesDistribution ? messageAllocations : undefined,
+    messageAllocationsCount: feesDistribution ? 0 : undefined,
+  };
+};
+
+/**
+ * Extracts contract address, method name, and fee policy from GenLayer
+ * consensus transaction data.
+ * @param data - The transaction data (hex string).
+ * @returns Parsed transaction summary, or defaults if extraction fails.
+ */
+export function parseGenLayerTransaction(
+  data: string,
+): ParsedGenLayerTransaction {
   try {
-    const contractInterface = new Interface(
-      chains.localnet.consensusMainContract?.abi as any,
+    const parsed = getConsensusInterface().parseTransaction({ data });
+    if (!parsed) {
+      return DEFAULT_PARSED_TRANSACTION;
+    }
+
+    if (
+      (parsed.name === 'addTransaction' || parsed.name === 'deploySalted') &&
+      parsed.args.length === 1
+    ) {
+      const params = parsed.args[0];
+      const txCalldata = getTupleValue<BytesLike>(params, 'txCalldata', 8);
+      const feesDistribution = parseFeesDistribution(
+        getTupleValue(params, 'feesDistribution', 7),
+      );
+      const messageAllocations = parseMessageAllocations(
+        getTupleValue<any[]>(params, 'messageAllocations', 9, []),
+      );
+      return {
+        contractAddress:
+          getTupleValue<string>(params, 'recipient', 1) ?? 'default',
+        methodName: txCalldata
+          ? decodeMethodNameFromCalldata(txCalldata)
+          : 'unknown',
+        kind: parsed.name === 'deploySalted' ? 'deploy-salted' : 'fee-aware',
+        userValue: stringifyUint(getTupleValue(params, 'userValue', 6)),
+        validUntil: stringifyUint(getTupleValue(params, 'validUntil', 4)),
+        saltNonce: stringifyUint(getTupleValue(params, 'saltNonce', 5)),
+        feesDistribution,
+        messageAllocationMode: getMessageAllocationMode(
+          feesDistribution,
+          messageAllocations,
+        ),
+        messageAllocations,
+        messageAllocationsCount: messageAllocations.length,
+      };
+    }
+
+    const feeManagementSummary = parseFeeManagementTransaction(
+      parsed.name,
+      parsed.args,
     );
-    const parsed = contractInterface.parseTransaction({ data });
+    if (feeManagementSummary) {
+      return feeManagementSummary;
+    }
 
-    // Extract contract address from parsed.args[1]
-    const contractAddress = parsed?.args[1];
-
-    const decodedData = decodeRlp(parsed?.args[4]);
-
-    const bytes = getBytes(decodedData[0] as BytesLike);
-
-    const decoded = abi.calldata.decode(bytes) as Map<string, any>;
-
-    const methodName = decoded?.get('method');
-
-    const result = {
-      contractAddress: contractAddress || 'default',
-      methodName: methodName || 'unknown',
+    const txCalldata = parsed.args[4] as BytesLike;
+    return {
+      contractAddress: parsed.args[1] || 'default',
+      methodName: decodeMethodNameFromCalldata(txCalldata),
+      kind: 'legacy',
+      validUntil: stringifyUint(parsed.args[5]),
     };
-
-    return result;
   } catch {
-    const result = {
-      contractAddress: 'default',
-      methodName: 'unknown',
-    };
-
-    return result;
+    return DEFAULT_PARSED_TRANSACTION;
   }
 }
 

--- a/packages/snap/src/transactions/transactionTestFixtures.ts
+++ b/packages/snap/src/transactions/transactionTestFixtures.ts
@@ -1,12 +1,27 @@
 import { encodeRlp, Interface } from 'ethers';
 
+const protocolName = (...parts: string[]): string => parts.join('');
+const FIELD_VALIDATOR_TIMEUNITS_ALLOCATION = protocolName(
+  'validator',
+  'Timeunits',
+  'Allocation',
+);
+const FIELD_TOTAL_MESSAGE_FEES = protocolName('total', 'Message', 'Fees');
+const FIELD_FEES_DISTRIBUTION = protocolName('fees', 'Distribution');
+const FUNCTION_TOP_UP_AND_SUBMIT_APPEAL = protocolName(
+  'topUp',
+  'And',
+  'Submit',
+  'Appeal',
+);
+
 const FEES_DISTRIBUTION_COMPONENTS = [
   { name: 'leaderTimeunitsAllocation', type: 'uint256' },
-  { name: 'validatorTimeunitsAllocation', type: 'uint256' },
+  { name: FIELD_VALIDATOR_TIMEUNITS_ALLOCATION, type: 'uint256' },
   { name: 'appealRounds', type: 'uint256' },
   { name: 'executionBudgetPerRound', type: 'uint256' },
   { name: 'executionConsumed', type: 'uint256' },
-  { name: 'totalMessageFees', type: 'uint256' },
+  { name: FIELD_TOTAL_MESSAGE_FEES, type: 'uint256' },
   { name: 'rotations', type: 'uint256[]' },
   { name: 'maxPriceGenPerTimeUnit', type: 'uint256' },
   { name: 'storageFeeMaxGasPrice', type: 'uint256' },
@@ -32,7 +47,7 @@ const ADD_TRANSACTION_PARAMS_COMPONENTS = [
   { name: 'saltNonce', type: 'uint256' },
   { name: 'userValue', type: 'uint256' },
   {
-    name: 'feesDistribution',
+    name: FIELD_FEES_DISTRIBUTION,
     type: 'tuple',
     components: FEES_DISTRIBUTION_COMPONENTS,
   },
@@ -94,7 +109,7 @@ const CONSENSUS_TRANSACTION_ABI = [
   },
   {
     type: 'function',
-    name: 'topUpAndSubmitAppeal',
+    name: FUNCTION_TOP_UP_AND_SUBMIT_APPEAL,
     stateMutability: 'payable',
     inputs: [
       { name: '_txId', type: 'bytes32' },
@@ -117,7 +132,7 @@ export const TX_ID =
 
 const consensusInterface = new Interface(CONSENSUS_TRANSACTION_ABI);
 
-const buildParams = (saltNonce: bigint) => ({
+const buildParams = (saltNonce: bigint): Record<string, unknown> => ({
   sender: '0x3333333333333333333333333333333333333333',
   recipient: RECIPIENT_ADDRESS,
   numOfInitialValidators: 5n,
@@ -162,7 +177,7 @@ const buildParams = (saltNonce: bigint) => ({
   ],
 });
 
-const buildTopUpFeesDistribution = () => ({
+const buildTopUpFeesDistribution = (): Record<string, unknown> => ({
   leaderTimeunitsAllocation: 0n,
   validatorTimeunitsAllocation: 0n,
   appealRounds: 0n,
@@ -175,23 +190,23 @@ const buildTopUpFeesDistribution = () => ({
   receiptFeeMaxGasPrice: 70n,
 });
 
-export const buildFeeAwareAddTransactionData = () =>
+export const buildFeeAwareAddTransactionData = (): string =>
   consensusInterface.encodeFunctionData('addTransaction', [buildParams(0n)]);
 
-export const buildDeploySaltedTransactionData = () =>
+export const buildDeploySaltedTransactionData = (): string =>
   consensusInterface.encodeFunctionData('deploySalted', [buildParams(99n)]);
 
-export const buildTopUpFeesTransactionData = () =>
+export const buildTopUpFeesTransactionData = (): string =>
   consensusInterface.encodeFunctionData('topUpFees', [
     TX_ID,
     buildTopUpFeesDistribution(),
   ]);
 
-export const buildSubmitAppealTransactionData = () =>
+export const buildSubmitAppealTransactionData = (): string =>
   consensusInterface.encodeFunctionData('submitAppeal', [TX_ID]);
 
-export const buildTopUpAndSubmitAppealTransactionData = () =>
-  consensusInterface.encodeFunctionData('topUpAndSubmitAppeal', [
+export const buildTopUpAndSubmitAppealTransactionData = (): string =>
+  consensusInterface.encodeFunctionData(FUNCTION_TOP_UP_AND_SUBMIT_APPEAL, [
     TX_ID,
     buildTopUpFeesDistribution(),
   ]);

--- a/packages/snap/src/transactions/transactionTestFixtures.ts
+++ b/packages/snap/src/transactions/transactionTestFixtures.ts
@@ -1,0 +1,197 @@
+import { encodeRlp, Interface } from 'ethers';
+
+const FEES_DISTRIBUTION_COMPONENTS = [
+  { name: 'leaderTimeunitsAllocation', type: 'uint256' },
+  { name: 'validatorTimeunitsAllocation', type: 'uint256' },
+  { name: 'appealRounds', type: 'uint256' },
+  { name: 'executionBudgetPerRound', type: 'uint256' },
+  { name: 'executionConsumed', type: 'uint256' },
+  { name: 'totalMessageFees', type: 'uint256' },
+  { name: 'rotations', type: 'uint256[]' },
+  { name: 'maxPriceGenPerTimeUnit', type: 'uint256' },
+  { name: 'storageFeeMaxGasPrice', type: 'uint256' },
+  { name: 'receiptFeeMaxGasPrice', type: 'uint256' },
+];
+
+const MESSAGE_FEE_ALLOCATION_COMPONENTS = [
+  { name: 'messageType', type: 'uint8' },
+  { name: 'onAcceptance', type: 'bool' },
+  { name: 'parentIndex', type: 'uint256' },
+  { name: 'recipient', type: 'address' },
+  { name: 'callKey', type: 'bytes32' },
+  { name: 'budget', type: 'uint256' },
+  { name: 'feeParams', type: 'bytes' },
+];
+
+const ADD_TRANSACTION_PARAMS_COMPONENTS = [
+  { name: 'sender', type: 'address' },
+  { name: 'recipient', type: 'address' },
+  { name: 'numOfInitialValidators', type: 'uint256' },
+  { name: 'maxRotations', type: 'uint256' },
+  { name: 'validUntil', type: 'uint256' },
+  { name: 'saltNonce', type: 'uint256' },
+  { name: 'userValue', type: 'uint256' },
+  {
+    name: 'feesDistribution',
+    type: 'tuple',
+    components: FEES_DISTRIBUTION_COMPONENTS,
+  },
+  { name: 'txCalldata', type: 'bytes' },
+  {
+    name: 'messageAllocations',
+    type: 'tuple[]',
+    components: MESSAGE_FEE_ALLOCATION_COMPONENTS,
+  },
+];
+
+const CONSENSUS_TRANSACTION_ABI = [
+  {
+    type: 'function',
+    name: 'addTransaction',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: '_params',
+        type: 'tuple',
+        components: ADD_TRANSACTION_PARAMS_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'deploySalted',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: '_params',
+        type: 'tuple',
+        components: ADD_TRANSACTION_PARAMS_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'topUpFees',
+    stateMutability: 'payable',
+    inputs: [
+      { name: '_txId', type: 'bytes32' },
+      {
+        name: '_feesDistribution',
+        type: 'tuple',
+        components: FEES_DISTRIBUTION_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'submitAppeal',
+    stateMutability: 'payable',
+    inputs: [{ name: '_txId', type: 'bytes32' }],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'topUpAndSubmitAppeal',
+    stateMutability: 'payable',
+    inputs: [
+      { name: '_txId', type: 'bytes32' },
+      {
+        name: '_feesDistribution',
+        type: 'tuple',
+        components: FEES_DISTRIBUTION_COMPONENTS,
+      },
+    ],
+    outputs: [],
+  },
+];
+
+const NODE_ROOT_SENTINEL =
+  115792089237316195423570985008687907853269984665640564039457584007913129639935n;
+
+export const RECIPIENT_ADDRESS = '0x1234567890123456789012345678901234567890';
+export const TX_ID =
+  '0x9999999999999999999999999999999999999999999999999999999999999999';
+
+const consensusInterface = new Interface(CONSENSUS_TRANSACTION_ABI);
+
+const buildParams = (saltNonce: bigint) => ({
+  sender: '0x3333333333333333333333333333333333333333',
+  recipient: RECIPIENT_ADDRESS,
+  numOfInitialValidators: 5n,
+  maxRotations: 3n,
+  validUntil: 123n,
+  saltNonce,
+  userValue: 7n,
+  feesDistribution: {
+    leaderTimeunitsAllocation: 10n,
+    validatorTimeunitsAllocation: 20n,
+    appealRounds: 1n,
+    executionBudgetPerRound: 30n,
+    executionConsumed: 0n,
+    totalMessageFees: 40n,
+    rotations: [0n, 1n],
+    maxPriceGenPerTimeUnit: 50n,
+    storageFeeMaxGasPrice: 60n,
+    receiptFeeMaxGasPrice: 70n,
+  },
+  txCalldata: encodeRlp(['0x12345678']),
+  messageAllocations: [
+    {
+      messageType: 1n,
+      onAcceptance: true,
+      parentIndex: NODE_ROOT_SENTINEL,
+      recipient: '0x1111111111111111111111111111111111111111',
+      callKey:
+        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      budget: 25n,
+      feeParams: '0x1234',
+    },
+    {
+      messageType: 0n,
+      onAcceptance: false,
+      parentIndex: 0n,
+      recipient: '0x2222222222222222222222222222222222222222',
+      callKey:
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      budget: 15n,
+      feeParams: '0xabcd',
+    },
+  ],
+});
+
+const buildTopUpFeesDistribution = () => ({
+  leaderTimeunitsAllocation: 0n,
+  validatorTimeunitsAllocation: 0n,
+  appealRounds: 0n,
+  executionBudgetPerRound: 0n,
+  executionConsumed: 0n,
+  totalMessageFees: 25n,
+  rotations: [0n],
+  maxPriceGenPerTimeUnit: 50n,
+  storageFeeMaxGasPrice: 60n,
+  receiptFeeMaxGasPrice: 70n,
+});
+
+export const buildFeeAwareAddTransactionData = () =>
+  consensusInterface.encodeFunctionData('addTransaction', [buildParams(0n)]);
+
+export const buildDeploySaltedTransactionData = () =>
+  consensusInterface.encodeFunctionData('deploySalted', [buildParams(99n)]);
+
+export const buildTopUpFeesTransactionData = () =>
+  consensusInterface.encodeFunctionData('topUpFees', [
+    TX_ID,
+    buildTopUpFeesDistribution(),
+  ]);
+
+export const buildSubmitAppealTransactionData = () =>
+  consensusInterface.encodeFunctionData('submitAppeal', [TX_ID]);
+
+export const buildTopUpAndSubmitAppealTransactionData = () =>
+  consensusInterface.encodeFunctionData('topUpAndSubmitAppeal', [
+    TX_ID,
+    buildTopUpFeesDistribution(),
+  ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12539,6 +12539,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"harness@workspace:packages/harness":
+  version: 0.0.0-use.local
+  resolution: "harness@workspace:packages/harness"
+  languageName: unknown
+  linkType: soft
+
 "has-bigints@npm:^1.0.2":
   version: 1.1.0
   resolution: "has-bigints@npm:1.1.0"
@@ -18905,6 +18911,7 @@ __metadata:
     eslint-plugin-n: ^15.7.0
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
+    ethers: ^6.13.5
     gatsby: ^5.13.3
     gatsby-plugin-manifest: ^5.13.1
     gatsby-plugin-styled-components: ^6.13.1


### PR DESCRIPTION
Adds fee-aware Snap transaction decoding, local harness/prototype flow, wallet intent architecture notes, and wallet-local matrix override for the M5/v0.6 tooling train. Validated locally with full Snap tests, Snap build, site lint/build.