### PR TITLE
fix(fees)!: canonical v0.6 ABI in harness/site/smoke; show the fee deposit in the snap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'v*-dev']
   pull_request:
 
 jobs:

--- a/packages/harness/scripts/smoke.mjs
+++ b/packages/harness/scripts/smoke.mjs
@@ -7,9 +7,11 @@ import {
   Interface,
   JsonRpcProvider,
   Wallet,
+  encodeRlp,
   hexlify,
   keccak256,
   parseEther,
+  parseUnits,
   toUtf8Bytes,
 } from 'ethers';
 
@@ -53,32 +55,33 @@ const params = {
   saltNonce: 1n,
   userValue: parseEther('0.01'),
   feesDistribution: {
-    leaderTimeoutFee: parseEther('0.001'),
-    validatorsTimeoutFee: parseEther('0.002'),
+    leaderTimeunitsAllocation: 100n,
+    validatorTimeunitsAllocation: 200n,
     appealRounds: 1n,
-    rollupUnifiedBudgetPerRound: parseEther('0.01'),
-    rollupUnifiedConsumed: 0n,
+    executionBudgetPerRound: parseEther('0.01'),
+    executionConsumed: 0n,
     totalMessageFees: parseEther('0.02'),
     rotations: [0n, 1n],
-    maxPriceGenPerTimeUnit: 120n,
+    maxPriceGenPerTimeUnit: parseEther('0.00000012'),
+    storageFeeMaxGasPrice: parseUnits('24', 'gwei'),
+    receiptFeeMaxGasPrice: parseUnits('24', 'gwei'),
   },
-  txCalldata: hexlify(
-    toUtf8Bytes(JSON.stringify({ method: 'ask_llm', args: [], prototype: true })),
-  ),
+  txCalldata: encodeRlp([
+    hexlify(
+      toUtf8Bytes(JSON.stringify({ method: 'ask_llm', args: [], prototype: true })),
+    ),
+  ]),
   messageAllocations: [
     {
+      messageType: 1,
+      onAcceptance: true,
       parentIndex:
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn,
       recipient: '0x2222222222222222222222222222222222222222',
-      functionSelector: '0x00000000',
+      callKey:
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
       budget: parseEther('0.02'),
-      feeParams: {
-        leaderTimeunitsAllocation: parseEther('0.001'),
-        validatorTimeunitsAllocation: parseEther('0.002'),
-        appealRounds: 1n,
-        rollupUnifiedBudgetPerRound: parseEther('0.005'),
-        rotations: [0n],
-      },
+      feeParams: '0x',
     },
   ],
 };
@@ -121,7 +124,7 @@ const parseKnownEvents = (receipt) =>
     }
   });
 
-const maxTotalFee = parseEther('0.083');
+const maxTotalFee = parseEther('0.061');
 const msgValue = params.userValue + maxTotalFee;
 
 const directTx = await shim.addTransaction(params, { value: msgValue });

--- a/packages/harness/src/GenLayerFeeShim.sol
+++ b/packages/harness/src/GenLayerFeeShim.sol
@@ -5,30 +5,26 @@ contract GenLayerFeeShim {
     uint256 public transactionCount;
 
     struct FeesDistribution {
-        uint256 leaderTimeoutFee;
-        uint256 validatorsTimeoutFee;
-        uint256 appealRounds;
-        uint256 rollupUnifiedBudgetPerRound;
-        uint256 rollupUnifiedConsumed;
-        uint256 totalMessageFees;
-        uint256[] rotations;
-        uint256 maxPriceGenPerTimeUnit;
-    }
-
-    struct MessageFeeParams {
         uint256 leaderTimeunitsAllocation;
         uint256 validatorTimeunitsAllocation;
         uint256 appealRounds;
-        uint256 rollupUnifiedBudgetPerRound;
+        uint256 executionBudgetPerRound;
+        uint256 executionConsumed;
+        uint256 totalMessageFees;
         uint256[] rotations;
+        uint256 maxPriceGenPerTimeUnit;
+        uint256 storageFeeMaxGasPrice;
+        uint256 receiptFeeMaxGasPrice;
     }
 
     struct MessageFeeAllocationNode {
+        uint8 messageType;
+        bool onAcceptance;
         uint256 parentIndex;
         address recipient;
-        bytes4 functionSelector;
+        bytes32 callKey;
         uint256 budget;
-        MessageFeeParams feeParams;
+        bytes feeParams;
     }
 
     struct AddTransactionParams {

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -266,42 +266,50 @@ const PROFILE_PRESETS: Record<
   Partial<
     Pick<
       PrototypeForm,
-      | 'leaderTimeoutFee'
-      | 'validatorsTimeoutFee'
+      | 'leaderTimeunitsAllocation'
+      | 'validatorTimeunitsAllocation'
       | 'appealRounds'
-      | 'rollupUnifiedBudgetPerRound'
+      | 'executionBudgetPerRound'
       | 'totalMessageFees'
       | 'rotations'
       | 'maxPriceGenPerTimeUnit'
+      | 'storageFeeMaxGasPrice'
+      | 'receiptFeeMaxGasPrice'
     >
   >
 > = {
   low: {
-    leaderTimeoutFee: '0.0005',
-    validatorsTimeoutFee: '0.001',
+    leaderTimeunitsAllocation: '50',
+    validatorTimeunitsAllocation: '100',
     appealRounds: '0',
-    rollupUnifiedBudgetPerRound: '0.004',
+    executionBudgetPerRound: '0.004',
     totalMessageFees: '0',
     rotations: '0',
-    maxPriceGenPerTimeUnit: '110',
+    maxPriceGenPerTimeUnit: '0.00000011',
+    storageFeeMaxGasPrice: '22',
+    receiptFeeMaxGasPrice: '22',
   },
   standard: {
-    leaderTimeoutFee: '0.001',
-    validatorsTimeoutFee: '0.002',
+    leaderTimeunitsAllocation: '100',
+    validatorTimeunitsAllocation: '200',
     appealRounds: '1',
-    rollupUnifiedBudgetPerRound: '0.01',
+    executionBudgetPerRound: '0.01',
     totalMessageFees: '0.02',
     rotations: '0,1',
-    maxPriceGenPerTimeUnit: '120',
+    maxPriceGenPerTimeUnit: '0.00000012',
+    storageFeeMaxGasPrice: '24',
+    receiptFeeMaxGasPrice: '24',
   },
   high: {
-    leaderTimeoutFee: '0.002',
-    validatorsTimeoutFee: '0.004',
+    leaderTimeunitsAllocation: '200',
+    validatorTimeunitsAllocation: '400',
     appealRounds: '2',
-    rollupUnifiedBudgetPerRound: '0.025',
+    executionBudgetPerRound: '0.025',
     totalMessageFees: '0.05',
     rotations: '0,1,1',
-    maxPriceGenPerTimeUnit: '150',
+    maxPriceGenPerTimeUnit: '0.00000015',
+    storageFeeMaxGasPrice: '30',
+    receiptFeeMaxGasPrice: '30',
   },
   custom: {},
 };
@@ -873,49 +881,75 @@ const Index = () => {
                 />
               </Field>
               <Field>
-                Leader timeout fee
+                Leader time units (seconds)
                 <Input
-                  value={form.leaderTimeoutFee}
+                  value={form.leaderTimeunitsAllocation}
                   onChange={(changeEvent) => {
                     updateForm('profile', 'custom');
-                    updateForm('leaderTimeoutFee', changeEvent.target.value);
+                    updateForm('leaderTimeunitsAllocation', changeEvent.target.value);
                   }}
                 />
               </Field>
               <Field>
-                Validator timeout fee
+                Validator time units (seconds)
                 <Input
-                  value={form.validatorsTimeoutFee}
+                  value={form.validatorTimeunitsAllocation}
                   onChange={(changeEvent) => {
                     updateForm('profile', 'custom');
                     updateForm(
-                      'validatorsTimeoutFee',
+                      'validatorTimeunitsAllocation',
                       changeEvent.target.value,
                     );
                   }}
                 />
               </Field>
               <Field>
-                Rollup budget / round
+                Execution budget / round (GEN)
                 <Input
-                  value={form.rollupUnifiedBudgetPerRound}
+                  value={form.executionBudgetPerRound}
                   onChange={(changeEvent) => {
                     updateForm('profile', 'custom');
                     updateForm(
-                      'rollupUnifiedBudgetPerRound',
+                      'executionBudgetPerRound',
                       changeEvent.target.value,
                     );
                   }}
                 />
               </Field>
               <Field>
-                Max GEN/time-unit
+                Max GEN/time-unit cap (price x 1.2 placeholder)
                 <Input
                   value={form.maxPriceGenPerTimeUnit}
                   onChange={(changeEvent) => {
                     updateForm('profile', 'custom');
                     updateForm(
                       'maxPriceGenPerTimeUnit',
+                      changeEvent.target.value,
+                    );
+                  }}
+                />
+              </Field>
+              <Field>
+                Storage gas cap (gwei, price x 1.2 placeholder)
+                <Input
+                  value={form.storageFeeMaxGasPrice}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm(
+                      'storageFeeMaxGasPrice',
+                      changeEvent.target.value,
+                    );
+                  }}
+                />
+              </Field>
+              <Field>
+                Receipt gas cap (gwei, price x 1.2 placeholder)
+                <Input
+                  value={form.receiptFeeMaxGasPrice}
+                  onChange={(changeEvent) => {
+                    updateForm('profile', 'custom');
+                    updateForm(
+                      'receiptFeeMaxGasPrice',
                       changeEvent.target.value,
                     );
                   }}
@@ -959,11 +993,11 @@ const Index = () => {
                     />
                   </FullField>
                   <Field>
-                    Selector
+                    Call key (bytes32)
                     <Input
-                      value={form.messageSelector}
+                      value={form.messageCallKey}
                       onChange={(changeEvent) =>
-                        updateForm('messageSelector', changeEvent.target.value)
+                        updateForm('messageCallKey', changeEvent.target.value)
                       }
                     />
                   </Field>

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -886,7 +886,10 @@ const Index = () => {
                   value={form.leaderTimeunitsAllocation}
                   onChange={(changeEvent) => {
                     updateForm('profile', 'custom');
-                    updateForm('leaderTimeunitsAllocation', changeEvent.target.value);
+                    updateForm(
+                      'leaderTimeunitsAllocation',
+                      changeEvent.target.value,
+                    );
                   }}
                 />
               </Field>

--- a/packages/site/src/prototype/transaction.ts
+++ b/packages/site/src/prototype/transaction.ts
@@ -2,6 +2,7 @@ import {
   AbiCoder,
   Interface,
   TypedDataEncoder,
+  encodeRlp,
   formatUnits,
   getAddress,
   hexlify,
@@ -35,49 +36,47 @@ export type PrototypeForm = {
   saltNonce: string;
   gatewayNonce: string;
   profile: FeeProfile;
-  leaderTimeoutFee: string;
-  validatorsTimeoutFee: string;
+  leaderTimeunitsAllocation: string;
+  validatorTimeunitsAllocation: string;
   appealRounds: string;
-  rollupUnifiedBudgetPerRound: string;
+  executionBudgetPerRound: string;
   totalMessageFees: string;
   rotations: string;
   maxPriceGenPerTimeUnit: string;
+  storageFeeMaxGasPrice: string;
+  receiptFeeMaxGasPrice: string;
   messageMode: MessageMode;
   messageRecipient: string;
-  messageSelector: string;
+  messageCallKey: string;
   messageBudget: string;
   messageLeaderTimeunits: string;
   messageValidatorTimeunits: string;
   messageAppealRounds: string;
-  messageRollupBudget: string;
+  messageExecutionBudget: string;
   messageRotations: string;
 };
 
 export type FeesDistribution = {
-  leaderTimeoutFee: bigint;
-  validatorsTimeoutFee: bigint;
-  appealRounds: bigint;
-  rollupUnifiedBudgetPerRound: bigint;
-  rollupUnifiedConsumed: bigint;
-  totalMessageFees: bigint;
-  rotations: bigint[];
-  maxPriceGenPerTimeUnit: bigint;
-};
-
-export type MessageFeeParams = {
   leaderTimeunitsAllocation: bigint;
   validatorTimeunitsAllocation: bigint;
   appealRounds: bigint;
-  rollupUnifiedBudgetPerRound: bigint;
+  executionBudgetPerRound: bigint;
+  executionConsumed: bigint;
+  totalMessageFees: bigint;
   rotations: bigint[];
+  maxPriceGenPerTimeUnit: bigint;
+  storageFeeMaxGasPrice: bigint;
+  receiptFeeMaxGasPrice: bigint;
 };
 
 export type MessageFeeAllocationNode = {
+  messageType: bigint;
+  onAcceptance: boolean;
   parentIndex: bigint;
   recipient: string;
-  functionSelector: string;
+  callKey: string;
   budget: bigint;
-  feeParams: MessageFeeParams;
+  feeParams: string;
 };
 
 export type AddTransactionParams = {
@@ -182,12 +181,12 @@ export const CONSENSUS_MAIN_WITH_FEES_ABI = [
             components: [
               {
                 internalType: 'uint256',
-                name: 'leaderTimeoutFee',
+                name: 'leaderTimeunitsAllocation',
                 type: 'uint256',
               },
               {
                 internalType: 'uint256',
-                name: 'validatorsTimeoutFee',
+                name: 'validatorTimeunitsAllocation',
                 type: 'uint256',
               },
               {
@@ -197,12 +196,12 @@ export const CONSENSUS_MAIN_WITH_FEES_ABI = [
               },
               {
                 internalType: 'uint256',
-                name: 'rollupUnifiedBudgetPerRound',
+                name: 'executionBudgetPerRound',
                 type: 'uint256',
               },
               {
                 internalType: 'uint256',
-                name: 'rollupUnifiedConsumed',
+                name: 'executionConsumed',
                 type: 'uint256',
               },
               {
@@ -220,6 +219,16 @@ export const CONSENSUS_MAIN_WITH_FEES_ABI = [
                 name: 'maxPriceGenPerTimeUnit',
                 type: 'uint256',
               },
+              {
+                internalType: 'uint256',
+                name: 'storageFeeMaxGasPrice',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'receiptFeeMaxGasPrice',
+                type: 'uint256',
+              },
             ],
             internalType: 'struct IFeeManager.FeesDistribution',
             name: 'feesDistribution',
@@ -228,46 +237,17 @@ export const CONSENSUS_MAIN_WITH_FEES_ABI = [
           { internalType: 'bytes', name: 'txCalldata', type: 'bytes' },
           {
             components: [
+              { internalType: 'uint8', name: 'messageType', type: 'uint8' },
+              { internalType: 'bool', name: 'onAcceptance', type: 'bool' },
               { internalType: 'uint256', name: 'parentIndex', type: 'uint256' },
               { internalType: 'address', name: 'recipient', type: 'address' },
               {
-                internalType: 'bytes4',
-                name: 'functionSelector',
-                type: 'bytes4',
+                internalType: 'bytes32',
+                name: 'callKey',
+                type: 'bytes32',
               },
               { internalType: 'uint256', name: 'budget', type: 'uint256' },
-              {
-                components: [
-                  {
-                    internalType: 'uint256',
-                    name: 'leaderTimeunitsAllocation',
-                    type: 'uint256',
-                  },
-                  {
-                    internalType: 'uint256',
-                    name: 'validatorTimeunitsAllocation',
-                    type: 'uint256',
-                  },
-                  {
-                    internalType: 'uint256',
-                    name: 'appealRounds',
-                    type: 'uint256',
-                  },
-                  {
-                    internalType: 'uint256',
-                    name: 'rollupUnifiedBudgetPerRound',
-                    type: 'uint256',
-                  },
-                  {
-                    internalType: 'uint256[]',
-                    name: 'rotations',
-                    type: 'uint256[]',
-                  },
-                ],
-                internalType: 'struct IMessages.MessageFeeParams',
-                name: 'feeParams',
-                type: 'tuple',
-              },
+              { internalType: 'bytes', name: 'feeParams', type: 'bytes' },
             ],
             internalType: 'struct IMessages.MessageFeeAllocationNode[]',
             name: 'messageAllocations',
@@ -286,7 +266,10 @@ export const CONSENSUS_MAIN_WITH_FEES_ABI = [
   },
 ];
 
-const addTransactionParamsInput = CONSENSUS_MAIN_WITH_FEES_ABI[0].inputs[0];
+const addTransactionParamsInput = CONSENSUS_MAIN_WITH_FEES_ABI[0]?.inputs[0];
+if (!addTransactionParamsInput) {
+  throw new Error('Missing addTransaction params input');
+}
 
 export const GENLAYER_INTENT_GATEWAY_ABI = [
   {
@@ -461,21 +444,24 @@ export const makeDefaultForm = (): PrototypeForm => ({
   saltNonce: '0',
   gatewayNonce: '0',
   profile: 'standard',
-  leaderTimeoutFee: '0.001',
-  validatorsTimeoutFee: '0.002',
+  leaderTimeunitsAllocation: '100',
+  validatorTimeunitsAllocation: '200',
   appealRounds: '1',
-  rollupUnifiedBudgetPerRound: '0.01',
+  executionBudgetPerRound: '0.01',
   totalMessageFees: '0.02',
   rotations: '0,1',
-  maxPriceGenPerTimeUnit: '120',
+  maxPriceGenPerTimeUnit: '0.00000012',
+  storageFeeMaxGasPrice: '24',
+  receiptFeeMaxGasPrice: '24',
   messageMode: 'mode1',
   messageRecipient: '0x2222222222222222222222222222222222222222',
-  messageSelector: '0x00000000',
+  messageCallKey:
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
   messageBudget: '0.02',
-  messageLeaderTimeunits: '0.001',
-  messageValidatorTimeunits: '0.002',
+  messageLeaderTimeunits: '100',
+  messageValidatorTimeunits: '200',
   messageAppealRounds: '1',
-  messageRollupBudget: '0.005',
+  messageExecutionBudget: '0.005',
   messageRotations: '0',
 });
 
@@ -521,6 +507,13 @@ const parseUint = (value: string): bigint => {
   return BigInt(parsed);
 };
 
+const parseGwei = (value: string): bigint => {
+  if (!value.trim()) {
+    return 0n;
+  }
+  return parseUnits(value.trim(), 'gwei');
+};
+
 const parseRotations = (value: string): bigint[] => {
   const rotations = value
     .split(',')
@@ -541,11 +534,11 @@ const normalizeAddress = (address: string, fallback = ZERO_ADDRESS): string => {
   return getAddress(address);
 };
 
-const normalizeBytes4 = (value: string): string => {
-  if (/^0x[0-9a-fA-F]{8}$/u.test(value)) {
+const normalizeBytes32 = (value: string): string => {
+  if (/^0x[0-9a-fA-F]{64}$/u.test(value)) {
     return value;
   }
-  return '0x00000000';
+  return '0x0000000000000000000000000000000000000000000000000000000000000000';
 };
 
 const buildTxCalldata = (methodName: string): string => {
@@ -555,36 +548,32 @@ const buildTxCalldata = (methodName: string): string => {
     prototype: true,
   };
 
-  return hexlify(toUtf8Bytes(JSON.stringify(payload)));
+  return encodeRlp([hexlify(toUtf8Bytes(JSON.stringify(payload)))]);
 };
 
 const toFeeTuple = (fees: FeesDistribution): unknown[] => [
-  fees.leaderTimeoutFee,
-  fees.validatorsTimeoutFee,
+  fees.leaderTimeunitsAllocation,
+  fees.validatorTimeunitsAllocation,
   fees.appealRounds,
-  fees.rollupUnifiedBudgetPerRound,
-  fees.rollupUnifiedConsumed,
+  fees.executionBudgetPerRound,
+  fees.executionConsumed,
   fees.totalMessageFees,
   fees.rotations,
   fees.maxPriceGenPerTimeUnit,
-];
-
-const toMessageFeeTuple = (feeParams: MessageFeeParams): unknown[] => [
-  feeParams.leaderTimeunitsAllocation,
-  feeParams.validatorTimeunitsAllocation,
-  feeParams.appealRounds,
-  feeParams.rollupUnifiedBudgetPerRound,
-  feeParams.rotations,
+  fees.storageFeeMaxGasPrice,
+  fees.receiptFeeMaxGasPrice,
 ];
 
 const toMessageAllocationTuple = (
   node: MessageFeeAllocationNode,
 ): unknown[] => [
+  node.messageType,
+  node.onAcceptance,
   node.parentIndex,
   node.recipient,
-  node.functionSelector,
+  node.callKey,
   node.budget,
-  toMessageFeeTuple(node.feeParams),
+  node.feeParams,
 ];
 
 const toAddTransactionTuple = (params: AddTransactionParams): unknown[] => [
@@ -607,14 +596,16 @@ export const buildFeesDistribution = (
     form.messageMode === 'none' ? 0n : parseGen(form.totalMessageFees);
 
   return {
-    leaderTimeoutFee: parseGen(form.leaderTimeoutFee),
-    validatorsTimeoutFee: parseGen(form.validatorsTimeoutFee),
+    leaderTimeunitsAllocation: parseUint(form.leaderTimeunitsAllocation),
+    validatorTimeunitsAllocation: parseUint(form.validatorTimeunitsAllocation),
     appealRounds: parseUint(form.appealRounds),
-    rollupUnifiedBudgetPerRound: parseGen(form.rollupUnifiedBudgetPerRound),
-    rollupUnifiedConsumed: 0n,
+    executionBudgetPerRound: parseGen(form.executionBudgetPerRound),
+    executionConsumed: 0n,
     totalMessageFees,
     rotations: parseRotations(form.rotations),
-    maxPriceGenPerTimeUnit: parseUint(form.maxPriceGenPerTimeUnit),
+    maxPriceGenPerTimeUnit: parseGen(form.maxPriceGenPerTimeUnit),
+    storageFeeMaxGasPrice: parseGwei(form.storageFeeMaxGasPrice),
+    receiptFeeMaxGasPrice: parseGwei(form.receiptFeeMaxGasPrice),
   };
 };
 
@@ -627,33 +618,46 @@ export const buildMessageAllocations = (
 
   return [
     {
+      messageType: 1n,
+      onAcceptance: true,
       parentIndex: ROOT_ALLOCATION_PARENT,
       recipient: normalizeAddress(form.messageRecipient),
-      functionSelector: normalizeBytes4(form.messageSelector),
+      callKey: normalizeBytes32(form.messageCallKey),
       budget: parseGen(form.messageBudget),
-      feeParams: {
-        leaderTimeunitsAllocation: parseGen(form.messageLeaderTimeunits),
-        validatorTimeunitsAllocation: parseGen(form.messageValidatorTimeunits),
-        appealRounds: parseUint(form.messageAppealRounds),
-        rollupUnifiedBudgetPerRound: parseGen(form.messageRollupBudget),
-        rotations: parseRotations(form.messageRotations),
-      },
+      feeParams: abiCoder.encode(
+        ['tuple(uint256,uint256,uint256,uint256,uint256[])'],
+        [
+          [
+            parseUint(form.messageLeaderTimeunits),
+            parseUint(form.messageValidatorTimeunits),
+            parseUint(form.messageAppealRounds),
+            parseGen(form.messageExecutionBudget),
+            parseRotations(form.messageRotations),
+          ],
+        ],
+      ),
     },
   ];
 };
 
 export const estimateFees = (params: AddTransactionParams): FeeEstimate => {
-  const rounds = Math.max(params.feesDistribution.rotations.length, 1);
+  const rounds = Number(params.feesDistribution.rotations[0] ?? 0n) + 1;
   const validators = params.numOfInitialValidators;
-  const leaderPerRound = params.feesDistribution.leaderTimeoutFee;
+  const leaderPerRound = params.feesDistribution.leaderTimeunitsAllocation;
   const validatorsPerRound =
-    params.feesDistribution.validatorsTimeoutFee * validators;
-  const rollupPerRound = params.feesDistribution.rollupUnifiedBudgetPerRound;
-  const timeoutFees = BigInt(rounds) * (leaderPerRound + validatorsPerRound);
-  const rollupBudget = BigInt(rounds) * rollupPerRound;
-  const appealBudget =
-    params.feesDistribution.appealRounds *
-    (leaderPerRound + validatorsPerRound + rollupPerRound);
+    params.feesDistribution.validatorTimeunitsAllocation * validators;
+  const timeunitFees = BigInt(rounds) * (leaderPerRound + validatorsPerRound);
+  const timeoutFees =
+    params.feesDistribution.maxPriceGenPerTimeUnit > 0n
+      ? timeunitFees * params.feesDistribution.maxPriceGenPerTimeUnit
+      : timeunitFees;
+  const leaderRounds = params.feesDistribution.rotations.reduce(
+    (sum, rotations) => sum + rotations + 1n,
+    params.feesDistribution.appealRounds,
+  );
+  const rollupBudget =
+    params.feesDistribution.executionBudgetPerRound * leaderRounds;
+  const appealBudget = 0n;
   const messageBudget = params.feesDistribution.totalMessageFees;
   const totalFees = timeoutFees + rollupBudget + appealBudget + messageBudget;
 
@@ -687,8 +691,8 @@ const hashFeeConfig = (params: AddTransactionParams): string =>
   keccak256(
     abiCoder.encode(
       [
-        'tuple(uint256,uint256,uint256,uint256,uint256,uint256,uint256[],uint256)',
-        'tuple(uint256,address,bytes4,uint256,tuple(uint256,uint256,uint256,uint256,uint256[]))[]',
+        'tuple(uint256,uint256,uint256,uint256,uint256,uint256,uint256[],uint256,uint256,uint256)',
+        'tuple(uint8,bool,uint256,address,bytes32,uint256,bytes)[]',
       ],
       [
         toFeeTuple(params.feesDistribution),
@@ -795,7 +799,7 @@ export const decodeGatewayNonceResult = (result: string): string =>
 export const parseHarnessReceiptEvents = (
   logs: RpcReceiptLog[],
 ): ParsedHarnessEvent[] =>
-  logs.flatMap((log) => {
+  logs.flatMap<ParsedHarnessEvent>((log) => {
     try {
       const parsed = harnessEventsInterface.parseLog({
         data: log.data,

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/genlayerlabs/genlayer-wallet.git"
   },
   "source": {
-    "shasum": "ZcFHxwG4tSjNc1K53JaHhrbyHUdNb6GSAGMVGHsCL9Y=",
+    "shasum": "jfn5mzHzvYalTqnEyAGtbXMe31eEsVbN9JwIfwNXsis=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/genlayerlabs/genlayer-wallet.git"
   },
   "source": {
-    "shasum": "jfn5mzHzvYalTqnEyAGtbXMe31eEsVbN9JwIfwNXsis=",
+    "shasum": "GPXu5lN1fOE8/A8BK0dwjnRfxLnlHrqTewXXi2dah/0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/genlayerlabs/genlayer-wallet.git"
   },
   "source": {
-    "shasum": "GPXu5lN1fOE8/A8BK0dwjnRfxLnlHrqTewXXi2dah/0=",
+    "shasum": "zxsJ8BlbFc10CInL3MhGsAzAGQKJEO2RxmYJCE6xd3w=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/components/TransactionConfig.tsx
+++ b/packages/snap/src/components/TransactionConfig.tsx
@@ -33,12 +33,7 @@ const formatWeiToGen = (value: string | undefined): string => {
 
   const fractionText = fraction.toString().padStart(18, '0');
   const significantDigits =
-    whole > 0n
-      ? 6
-      : Math.max(
-          6,
-          fractionText.search(/[1-9]/u) + 6,
-        );
+    whole > 0n ? 6 : Math.max(6, fractionText.search(/[1-9]/u) + 6);
   const trimmedFraction = fractionText
     .slice(0, Math.min(significantDigits, 18))
     .replace(/0+$/u, '');

--- a/packages/snap/src/components/TransactionConfig.tsx
+++ b/packages/snap/src/components/TransactionConfig.tsx
@@ -17,6 +17,35 @@ export type TransactionConfigProps = {
 
 const displayValue = (value: string | undefined): string => value ?? 'unknown';
 
+const WEI_PER_GEN = 1_000_000_000_000_000_000n;
+
+const formatWeiToGen = (value: string | undefined): string => {
+  if (value === undefined) {
+    return 'unknown';
+  }
+
+  const wei = BigInt(value);
+  const whole = wei / WEI_PER_GEN;
+  const fraction = wei % WEI_PER_GEN;
+  if (fraction === 0n) {
+    return `${whole.toString()} GEN`;
+  }
+
+  const fractionText = fraction.toString().padStart(18, '0');
+  const significantDigits =
+    whole > 0n
+      ? 6
+      : Math.max(
+          6,
+          fractionText.search(/[1-9]/u) + 6,
+        );
+  const trimmedFraction = fractionText
+    .slice(0, Math.min(significantDigits, 18))
+    .replace(/0+$/u, '');
+
+  return `${whole.toString()}.${trimmedFraction} GEN`;
+};
+
 const allocationSummary = (
   allocation: NonNullable<
     ParsedGenLayerTransaction['messageAllocations']
@@ -35,6 +64,12 @@ export const TransactionConfig: SnapComponent<TransactionConfigProps> = ({
   const messageAllocations = transactionSummary?.messageAllocations ?? [];
   const messageAllocationsCount =
     transactionSummary?.messageAllocationsCount ?? 0;
+  const totalValue = transactionSummary?.totalValue;
+  const userValue = transactionSummary?.userValue;
+  const feeDeposit = transactionSummary?.feeDeposit;
+  const isAppealPayment =
+    transactionSummary?.kind === 'submit-appeal' ||
+    transactionSummary?.kind === 'top-up-and-submit-appeal';
 
   return (
     <Box>
@@ -64,10 +99,42 @@ export const TransactionConfig: SnapComponent<TransactionConfigProps> = ({
         <Divider />
         <Box direction="horizontal" alignment={'space-between'}>
           <Text>
+            <Bold>Total:</Bold>
+          </Text>
+          <Text>{formatWeiToGen(totalValue)}</Text>
+        </Box>
+        <Text>
+          <Italic>Raw total: {displayValue(totalValue)} wei</Italic>
+        </Text>
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>
+            <Bold>Fee deposit:</Bold>
+          </Text>
+          <Text>
+            {formatWeiToGen(feeDeposit)} (+ userValue{' '}
+            {formatWeiToGen(userValue)})
+          </Text>
+        </Box>
+        <Text>
+          <Italic>Raw fee deposit: {displayValue(feeDeposit)} wei</Italic>
+        </Text>
+        {isAppealPayment ? (
+          <Box direction="horizontal" alignment={'space-between'}>
+            <Text>
+              <Bold>Bond/value paid:</Bold>
+            </Text>
+            <Text>{formatWeiToGen(totalValue)}</Text>
+          </Box>
+        ) : null}
+        <Box direction="horizontal" alignment={'space-between'}>
+          <Text>
             <Bold>User value:</Bold>
           </Text>
-          <Text>{displayValue(transactionSummary?.userValue)}</Text>
+          <Text>{formatWeiToGen(userValue)}</Text>
         </Box>
+        <Text>
+          <Italic>Raw user value: {displayValue(userValue)} wei</Italic>
+        </Text>
         <Box direction="horizontal" alignment={'space-between'}>
           <Text>Leader time units:</Text>
           <Text>

--- a/packages/snap/src/index.test.tsx
+++ b/packages/snap/src/index.test.tsx
@@ -61,6 +61,11 @@ describe('Snap Handlers', () => {
         methodName: 'transfer',
         kind: 'fee-aware',
       };
+      const mockTransactionSummaryWithValue = {
+        ...mockTransactionSummary,
+        totalValue: '2748',
+        feeDeposit: '2748',
+      };
 
       (getTransactionStorageKey as jest.Mock).mockReturnValue(mockStorageKey);
       (parseGenLayerTransaction as jest.Mock).mockReturnValue(
@@ -80,7 +85,7 @@ describe('Snap Handlers', () => {
       );
       expect(StateManager.set).toHaveBeenCalledWith(
         `${mockStorageKey}:transactionSummary`,
-        mockTransactionSummary,
+        mockTransactionSummaryWithValue,
       );
       expect(result).toEqual({ id: 'test-interface-id' });
     });

--- a/packages/snap/src/index.tsx
+++ b/packages/snap/src/index.tsx
@@ -30,9 +30,43 @@ const getCurrentTransactionSummary = async () => {
 const toJsonTransactionSummary = (summary: ParsedGenLayerTransaction) =>
   JSON.parse(JSON.stringify(summary)) as ParsedGenLayerTransaction;
 
+const parseTransactionValue = (value: unknown): bigint | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return undefined;
+  }
+};
+
+const withTransactionValue = (
+  summary: ParsedGenLayerTransaction,
+  value: unknown,
+): ParsedGenLayerTransaction => {
+  const totalValue = parseTransactionValue(value);
+  if (totalValue === undefined) {
+    return summary;
+  }
+
+  const userValue =
+    summary.userValue === undefined ? 0n : BigInt(summary.userValue);
+  const feeDeposit = totalValue > userValue ? totalValue - userValue : 0n;
+
+  return {
+    ...summary,
+    totalValue: totalValue.toString(),
+    feeDeposit: feeDeposit.toString(),
+  };
+};
+
 export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
   const storageKey = getTransactionStorageKey(transaction);
-  const transactionSummary = parseGenLayerTransaction(transaction.data ?? '');
+  const transactionSummary = withTransactionValue(
+    parseGenLayerTransaction(transaction.data ?? ''),
+    transaction.value,
+  );
   const jsonTransactionSummary = toJsonTransactionSummary(transactionSummary);
   await StateManager.set('currentStorageKey', storageKey);
   await StateManager.set(

--- a/packages/snap/src/index.tsx
+++ b/packages/snap/src/index.tsx
@@ -30,15 +30,17 @@ const getCurrentTransactionSummary = async () => {
 const toJsonTransactionSummary = (summary: ParsedGenLayerTransaction) =>
   JSON.parse(JSON.stringify(summary)) as ParsedGenLayerTransaction;
 
+const NUMERIC_VALUE_PATTERN = /^(0x[0-9a-fA-F]+|\d+)$/u;
+
 const parseTransactionValue = (value: unknown): bigint | undefined => {
   if (typeof value !== 'string') {
     return undefined;
   }
-  try {
-    return BigInt(value);
-  } catch {
+  const trimmed = value.trim();
+  if (!NUMERIC_VALUE_PATTERN.test(trimmed)) {
     return undefined;
   }
+  return BigInt(trimmed);
 };
 
 const withTransactionValue = (

--- a/packages/snap/src/transactions/transaction.integration.test.ts
+++ b/packages/snap/src/transactions/transaction.integration.test.ts
@@ -1,5 +1,9 @@
 import { abi } from 'genlayer-js';
 
+import {
+  buildTransaction,
+  makeDefaultForm,
+} from '../../../site/src/prototype/transaction';
 import { parseGenLayerTransaction } from './transaction';
 import {
   buildDeploySaltedTransactionData,
@@ -75,6 +79,37 @@ describe('Transaction Utilities integration', () => {
       ],
       messageAllocationsCount: 2,
     });
+  });
+
+  it('decodes fee-aware addTransaction calldata built by the site encoder', () => {
+    const built = buildTransaction({
+      ...makeDefaultForm(),
+      messageMode: 'mode2',
+    });
+    const result = parseGenLayerTransaction(built.addTransactionCalldata);
+
+    expect(result.kind).toBe('fee-aware');
+    expect(result.contractAddress).toBe(
+      '0x1111111111111111111111111111111111111111',
+    );
+    expect(result.methodName).toBe('claim');
+    expect(result.feesDistribution).toStrictEqual({
+      leaderTimeunitsAllocation: '100',
+      validatorTimeunitsAllocation: '200',
+      appealRounds: '1',
+      executionBudgetPerRound: '10000000000000000',
+      executionConsumed: '0',
+      totalMessageFees: '20000000000000000',
+      rotations: ['0', '1'],
+      maxPriceGenPerTimeUnit: '120000000000',
+      storageFeeMaxGasPrice: '24000000000',
+      receiptFeeMaxGasPrice: '24000000000',
+    });
+    expect(result.messageAllocationMode).toBe('mode-2');
+    expect(result.messageAllocationsCount).toBe(1);
+    expect(result.messageAllocations?.[0]?.callKey).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    );
   });
 
   it('decodes deploySalted fee-aware calldata as a deploy transaction', () => {

--- a/packages/snap/src/transactions/transaction.ts
+++ b/packages/snap/src/transactions/transaction.ts
@@ -60,6 +60,8 @@ export type ParsedGenLayerTransaction = {
   methodName: string;
   kind: TransactionKind;
   txId?: string | undefined;
+  totalValue?: string | undefined;
+  feeDeposit?: string | undefined;
   userValue?: string | undefined;
   validUntil?: string | undefined;
   saltNonce?: string | undefined;
@@ -358,11 +360,15 @@ const getMessageAllocationMode = (
 };
 
 const decodeMethodNameFromCalldata = (txCalldata: BytesLike): string => {
-  const decodedData = decodeRlp(txCalldata);
-  const bytes = getBytes(decodedData[0] as BytesLike);
-  const decoded = abi.calldata.decode(bytes) as Map<string, unknown>;
-  const method = decoded?.get('method');
-  return typeof method === 'string' ? method : 'unknown';
+  try {
+    const decodedData = decodeRlp(txCalldata);
+    const bytes = getBytes(decodedData[0] as BytesLike);
+    const decoded = abi.calldata.decode(bytes) as Map<string, unknown>;
+    const method = decoded?.get('method');
+    return typeof method === 'string' ? method : 'unknown';
+  } catch {
+    return 'unknown';
+  }
 };
 
 const parseFeeManagementTransaction = (


### PR DESCRIPTION
From the fee audit: the snap's parser was already canonical-correct, but the E2E scaffolding around it encoded a stale pre-CON-504 protocol — transactions built by the site couldn't be parsed by the snap's own fee-aware branch, so green wallet E2E proved nothing about v0.6.

- Harness `GenLayerFeeShim.sol`, site prototype encoder, and smoke script now encode the canonical shapes (10-field FeesDistribution incl. the three price caps; `MessageFeeAllocationNode` with messageType/onAcceptance/callKey/bytes feeParams), byte-matching the snap parser and genlayer-js.
- Site fee math replaced with the consensus round-0 formula; units fixed (time-unit allocations are integer seconds, not `parseUnits(x, 18)`; realistic cap placeholders instead of '110'/'150').
- Snap insight panel now shows Total / **Fee deposit** (= value − userValue) / userValue in GEN (raw wei secondary), and the bond being paid on appeal flows — previously the one number that matters was never displayed.
- Integration test asserts a SITE-encoded transaction parses as fee-aware (fixture built by the site encoder, not the snap's own ABI constants — kills the self-referential fixture blind spot).
- `snap.manifest.json` shasum updated from an actual build.

forge build, site+snap builds, lint, and snap test suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GEN-denominated formatting for transaction values and richer fee/value display
  * UI inputs for storage/receipt gas price caps, leader/validator timeunit allocations, and per-round execution budget
  * Message call-key input and updated transaction payload encoding for submitted intents

* **Bug Fixes**
  * More robust handling of malformed or unexpected transaction calldata

* **Refactor**
  * Overhauled fee configuration and message allocation schema

* **Tests**
  * Added integration test to decode fee-aware transactions

* **Chores**
  * Updated package manifest checksum
<!-- end of auto-generated comment: release notes by coderabbit.ai -->