### PR TITLE
docs: add branching guide

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -85,6 +85,12 @@ jobs:
           path: ./packages/snap/dist
           key: snap-${{ runner.os }}-${{ github.sha }}
       - run: yarn install --immutable
+      - name: Build snap if cache is empty
+        shell: bash
+        run: |
+          if [[ ! -f packages/snap/dist/bundle.js ]]; then
+            yarn workspace genlayer-wallet-plugin build
+          fi
       - name: Run e2e tests
         run: yarn workspace genlayer-wallet-plugin run test
       - name: Require clean working directory

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # How to Connect to GenLayer Localnet via MetaMask
 
+## Branching
+
+See [docs/BRANCHING.md](docs/BRANCHING.md) for the release-train model used by
+this repo.
+
 Follow these steps to add the GenLayer Localnet as a custom network in MetaMask:
 
 ## Step 1: Open MetaMask

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,58 @@
+# Branching and Release Trains
+
+This repo follows the GenLayer release-train model.
+
+## Current Train
+
+- Current stable branch: `v0.1`
+- Active integration branch: `v0.2-dev`
+- Next stable target: `v0.2`
+- `main`: default/static branch alias for the active integration branch
+
+## Stable Branches
+
+Stable branches are long-lived release lines. For semver-zero packages, each
+minor line is treated as the release line, for example `v0.1` or `v0.2`.
+
+PRs may target a stable branch directly when the merged result should be
+releasable immediately. This is appropriate for bug fixes, small non-breaking
+features, isolated release fixes, or a breaking change that is intentionally
+shipping as the next version by itself.
+
+Stable branches must remain releasable. PRs into stable branches are expected to
+pass the required cross-repo `E2E Tests` gate before merge.
+
+## Integration Branches
+
+Integration branches are optional. Use one when multiple changes need to
+accumulate before release, especially for cross-repo work, dependent features,
+breaking changes that must ship together, or a train that needs advisory E2E
+while still expected to be red.
+
+Integration branches are named after the target stable branch plus `-dev`, for
+example `v0.2-dev`. Feature PRs for that train target the integration branch.
+
+PRs into integration branches may run `E2E Tests` as advisory checks. They are
+not the release gate.
+
+## Promotion and Release
+
+When an integration train is ready, open a promotion PR from the integration
+branch to the matching stable branch, for example `v0.2-dev` to `v0.2`.
+
+That promotion PR is the release-readiness gate and must pass required
+cross-repo `E2E Tests`. The actual package release is cut from the stable branch
+using a version tag after the stable branch is ready.
+
+## `main`
+
+`main` exists for GitHub UX and tools that require a stable default branch. It is
+not a release branch and it is not the integration target.
+
+This repo keeps `main` forwarded to the active integration branch using
+automation. PRs opened against `main` are automatically retargeted to the branch
+listed in `support/ci/ACTIVE_DEV_BRANCH`.
+
+When changing the active integration branch, update
+`support/ci/ACTIVE_DEV_BRANCH`, the repo docs, and the corresponding
+`genlayer-e2e` release-train matrix in the same change set.


### PR DESCRIPTION
## Summary

- add docs/BRANCHING.md describing stable branches, optional integration branches, promotion PRs, E2E gates, releases, and main behavior
- link the guide from README

## Testing

- Docs-only change; no test suite run.