### PR TITLE
fix: include appeal rounds in timeout fee estimates

### DIFF
--- a/packages/site/src/prototype/transaction.ts
+++ b/packages/site/src/prototype/transaction.ts
@@ -161,6 +161,27 @@ export const ROOT_ALLOCATION_PARENT = BigInt(
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
 );
 
+const VALIDATORS_PER_ROUND = [
+  5n,
+  7n,
+  11n,
+  13n,
+  23n,
+  25n,
+  47n,
+  49n,
+  95n,
+  97n,
+  191n,
+  193n,
+  383n,
+  385n,
+  767n,
+  769n,
+  1535n,
+  1537n,
+] as const;
+
 export const CONSENSUS_MAIN_WITH_FEES_ABI = [
   {
     inputs: [
@@ -642,11 +663,53 @@ export const buildMessageAllocations = (
 
 export const estimateFees = (params: AddTransactionParams): FeeEstimate => {
   const rounds = Number(params.feesDistribution.rotations[0] ?? 0n) + 1;
-  const validators = params.numOfInitialValidators;
   const leaderPerRound = params.feesDistribution.leaderTimeunitsAllocation;
-  const validatorsPerRound =
-    params.feesDistribution.validatorTimeunitsAllocation * validators;
-  const timeunitFees = BigInt(rounds) * (leaderPerRound + validatorsPerRound);
+  const validatorPerRound =
+    params.feesDistribution.validatorTimeunitsAllocation;
+  const startIndex = VALIDATORS_PER_ROUND.findIndex(
+    (validators) => validators === params.numOfInitialValidators,
+  );
+  const appealRounds = Number(params.feesDistribution.appealRounds);
+  if (
+    startIndex < 0 ||
+    params.feesDistribution.appealRounds !==
+      BigInt(params.feesDistribution.rotations.length - 1) ||
+    startIndex + appealRounds * 2 >= VALIDATORS_PER_ROUND.length
+  ) {
+    throw new Error('Invalid fee validator schedule');
+  }
+
+  const initialValidators = VALIDATORS_PER_ROUND[startIndex];
+  if (initialValidators === undefined) {
+    throw new Error('Invalid fee validator schedule');
+  }
+  let timeunitFees =
+    BigInt(rounds) * (leaderPerRound + initialValidators * validatorPerRound);
+  let rotationsIndex = 1;
+  let rotationsThisRound = 1n;
+  for (let offset = 1; offset <= appealRounds * 2; offset += 1) {
+    if (
+      offset % 2 === 0 &&
+      rotationsIndex < params.feesDistribution.rotations.length
+    ) {
+      const configuredRotations =
+        params.feesDistribution.rotations[rotationsIndex];
+      if (configuredRotations === undefined) {
+        throw new Error('Invalid fee validator schedule');
+      }
+      rotationsThisRound = configuredRotations + 1n;
+      rotationsIndex += 1;
+    } else if (offset % 2 === 1) {
+      rotationsThisRound = 1n;
+    }
+    const roundValidators = VALIDATORS_PER_ROUND[startIndex + offset];
+    if (roundValidators === undefined) {
+      throw new Error('Invalid fee validator schedule');
+    }
+    timeunitFees +=
+      rotationsThisRound *
+      (leaderPerRound + roundValidators * validatorPerRound);
+  }
   const timeoutFees =
     params.feesDistribution.maxPriceGenPerTimeUnit > 0n
       ? timeunitFees * params.feesDistribution.maxPriceGenPerTimeUnit

--- a/packages/snap/src/transactions/bugHuntV02Dev.test.ts
+++ b/packages/snap/src/transactions/bugHuntV02Dev.test.ts
@@ -1,5 +1,6 @@
 import {
   buildAddTransactionParams,
+  estimateFees,
   makeDefaultForm,
 } from '../../../site/src/prototype/transaction';
 
@@ -13,5 +14,36 @@ describe('v0.2-dev bug hunt regressions', () => {
     });
 
     expect(params.saltNonce).toBe(BigInt(saltNonce));
+  });
+
+  it('includes appeal tribunals and appealed rounds in timeout fees', () => {
+    const estimate = estimateFees({
+      sender: '0x0000000000000000000000000000000000000000',
+      recipient: '0x0000000000000000000000000000000000000001',
+      numOfInitialValidators: 5n,
+      maxRotations: 2n,
+      validUntil: 0n,
+      saltNonce: 0n,
+      userValue: 0n,
+      txCalldata: '0x',
+      messageAllocations: [],
+      feesDistribution: {
+        leaderTimeunitsAllocation: 10n,
+        validatorTimeunitsAllocation: 1n,
+        appealRounds: 1n,
+        executionBudgetPerRound: 0n,
+        executionConsumed: 0n,
+        totalMessageFees: 0n,
+        rotations: [0n, 1n],
+        maxPriceGenPerTimeUnit: 2n,
+        storageFeeMaxGasPrice: 0n,
+        receiptFeeMaxGasPrice: 0n,
+      },
+    });
+
+    // 5 validators once, 7-validator appeal tribunal once, then 11
+    // validators for two rotations: (15 + 17 + 42) * 2.
+    expect(estimate.timeoutFees).toBe(148n);
+    expect(estimate.totalFees).toBe(148n);
   });
 });


### PR DESCRIPTION
## Summary
- apply the consensus validator schedule across appeals and appealed rounds
- include each round's rotations in timeout fees
- validate malformed fee schedules and add an appeal regression test

## Verification
- focused Jest suite (2 passed)
- focused ESLint/Prettier check